### PR TITLE
fix: align TextMate grammar scopes to official conventions and fix tokenization edge cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5",
     "typescript-eslint": "^8.14.0",
-    "vscode": "^1.1.37"
+    "vscode": "^1.1.37",
+    "vscode-oniguruma": "^2.0.1",
+    "vscode-textmate": "^9.3.2"
   },
   "nyc": {
     "include": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,12 @@ importers:
       vscode:
         specifier: ^1.1.37
         version: 1.1.37
+      vscode-oniguruma:
+        specifier: ^2.0.1
+        version: 2.0.1
+      vscode-textmate:
+        specifier: ^9.3.2
+        version: 9.3.2
 
 packages:
 
@@ -2292,10 +2298,16 @@ packages:
     resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
     engines: {node: '>=4'}
 
+  vscode-oniguruma@2.0.1:
+    resolution: {integrity: sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==}
+
   vscode-test@0.4.3:
     resolution: {integrity: sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==}
     engines: {node: '>=8.9.3'}
     deprecated: This package has been renamed to @vscode/test-electron, please update to the new name
+
+  vscode-textmate@9.3.2:
+    resolution: {integrity: sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==}
 
   vscode@1.1.37:
     resolution: {integrity: sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==}
@@ -4844,12 +4856,16 @@ snapshots:
 
   version-range@4.15.0: {}
 
+  vscode-oniguruma@2.0.1: {}
+
   vscode-test@0.4.3:
     dependencies:
       http-proxy-agent: 2.1.0
       https-proxy-agent: 2.2.4
     transitivePeerDependencies:
       - supports-color
+
+  vscode-textmate@9.3.2: {}
 
   vscode@1.1.37:
     dependencies:

--- a/src/utils/vscode-utils.ts
+++ b/src/utils/vscode-utils.ts
@@ -4,7 +4,7 @@ import {ErrorHandler} from './error-handler';
 type LocationCtor = new (uri: vscode.Uri, range: vscode.Range) => vscode.Location;
 
 const locationCtor: LocationCtor | undefined =
-    typeof vscode.Location === 'function' ? vscode.Location : undefined;
+    typeof vscode.Location === 'function' ? (vscode.Location) : undefined;
 
 /**
  * Creates a VS Code Location object in a test-compatible way.

--- a/syntaxes/thrift.tmLanguage.json
+++ b/syntaxes/thrift.tmLanguage.json
@@ -6,6 +6,9 @@
       "include": "#comments"
     },
     {
+      "include": "#namespace-definitions"
+    },
+    {
       "include": "#const-definitions"
     },
     {
@@ -93,12 +96,12 @@
               "match": "\\b[0-9]+\\b"
             },
             {
-              "name": "constant.language.thrift",
+              "name": "constant.language.boolean.thrift",
               "match": "\\b(true|false)\\b"
             },
             {
               "name": "keyword.other.annotation.thrift",
-              "match": "\\b(accessor|json_name|cpp.name|java.name|py.name|js.name|go.name|php.name|rb.name|csharp.name|swift.name|rust.name|scala.name|kotlin.name|dart.name|lua.name|perl.name|rust.name|haskell.name|elixir.name|clojure.name|erlang.name|nim.name|zig.name|v.name|odin.name|crystal.name|d.name|groovy.name|julia.name|r.name|matlab.name|fortran.name|pascal.name|ada.name|objc.name|asm.name|llvm.name|wasm.name|spir.name|hlsl.name|glsl.name|msl.name|cuda.name|opencl.name|vulkan.name|metal.name|opengl.name|directx.name|cpp.virtual|java.annotations|cpp.include|cpp.type|cpp.ref_type|cpp.container_type|cpp.getter|cpp.setter|cpp.field|cpp.methods|cpp.allocator|cpp.copy|cpp.equals|cpp.hash|cpp.to_string|cpp.ostream|cpp.istream|cpp.serializable|cpp.bean|cpp.final|cpp.exception|cpp.enum|cpp.union|cpp.struct|cpp.service|cpp.const|cpp.typedef|cpp.namespace|cpp.include|cpp.package|cpp.header|cpp.out|cpp.ref|cpp.unique_ptr|cpp.shared_ptr|cpp.weak_ptr|cpp.optional|cpp.required|cpp.default_value|cpp.adapter|cpp.name|cpp.marshal|cpp.size|cpp.reserved|cpp.deprecated|cpp.experimental|cpp.internal|cpp.private|cpp.protected|cpp.public|cpp.static|cpp.const|cpp.virtual|cpp.abstract|cpp.interface|cpp.template|cpp.generic|cpp.specialization|cpp.overload|cpp.override|cpp.final|cpp.sealed|cpp.immutable|cpp.mutable|cpp.thread_safe|cpp.not_thread_safe|cpp.guarded_by|cpp.acquired_after|cpp.acquired_before|cpp.return_pointer|cpp.return_reference|cpp.return_value|cpp.param|cpp.throws|cpp.nothrow|cpp.noexcept|cpp.deprecated|cpp.fallthrough|cpp.nodiscard|cpp.maybe_unused|cpp.likely|cpp.unlikely|cpp.assume|cpp.assert|cpp.static_assert|cpp.constexpr|cpp.consteval|cpp.constinit|cpp.inline|cpp.no_inline|cpp.force_inline|cpp.weak|cpp.strong|cpp.used|cpp.unused|cpp.retain|cpp.release|cpp.bridge|cpp.callback|cpp.event|cpp.property|cpp.indexer|cpp.operator|cpp.conversion|cpp.iterator|cpp.range|cpp.container|cpp.algorithm|cpp.functional|cpp.thread|cpp.mutex|cpp.lock|cpp.condition_variable|cpp.atomic|cpp.memory|cpp.smart_ptr|cpp.string|cpp.vector|cpp.list|cpp.deque|cpp.set|cpp.map|cpp.unordered_set|cpp.unordered_map|cpp.array|cpp.tuple|cpp.pair|cpp.optional|cpp.variant|cpp.any|cpp.function|cpp.bind|cpp.ref|cpp.reference_wrapper|cpp.memory_resource|cpp.polymorphic_allocator|cpp.allocator|cpp.deleter|cpp.cloner|cpp.comparator|cpp.hasher|cpp.equal_to|cpp.less|cpp.greater|cpp.plus|cpp.minus|cpp.multiplies|cpp.divides|cpp.modulus|cpp.negate|cpp.logical_and|cpp.logical_or|cpp.logical_not|cpp.bit_and|cpp.bit_or|cpp.bit_xor|cpp.bit_not|cpp.shift_left|cpp.shift_right|cpp.unary_plus|cpp.unary_minus|cpp.dereference|cpp.address_of|cpp.subscript|cpp.call|cpp.comma|cpp.ternary|cpp.cast|cpp.const_cast|cpp.static_cast|cpp.dynamic_cast|cpp.reinterpret_cast|cpp.new|cpp.delete|cpp.new_array|cpp.delete_array|cpp.malloc|cpp.free|cpp.calloc|cpp.realloc|cpp.memcpy|cpp.memmove|cpp.memset|cpp.memcmp|cpp.strcpy|cpp.strncpy|cpp.strcat|cpp.strncat|cpp.strcmp|cpp.strncmp|cpp.strlen|cpp.strchr|cpp.strrchr|cpp.strstr|cpp.strtok|cpp.sprintf|cpp.sscanf|cpp.fprintf|cpp.fscanf|cpp.printf|cpp.scanf|cpp.cout|cpp.cin|cpp.cerr|cpp.clog|cpp.endl|cpp.flush|cpp.dec|cpp.hex|cpp.oct|cpp.fixed|cpp.scientific|cpp.defaultfloat|cpp.boolalpha|cpp.noboolalpha|cpp.showbase|cpp.noshowbase|cpp.showpoint|cpp.noshowpoint|cpp.showpos|cpp.noshowpos|cpp.skipws|cpp.noskipws|cpp.uppercase|cpp.nouppercase|cpp.internal|cpp.left|cpp.right|cpp.setfill|cpp.setprecision|cpp.setw|cpp.resetiosflags|cpp.setiosflags|cpp.boolalpha|cpp.noboolalpha|cpp.showbase|cpp.noshowbase|cpp.showpoint|cpp.noshowpoint|cpp.showpos|cpp.noshowpos|cpp.skipws|cpp.noskipws|cpp.uppercase|cpp.nouppercase|cpp.unitbuf|cpp.nounitbuf|cpp.adjustfield|cpp.basefield|cpp.floatfield|cpp.errc|cpp.io_errc|cpp.stream_errc|cpp future_errc|cpp.condition_variable_any|cpp.stop_token|cpp.stop_source|cpp.jthread|cpp.barrier|cpp.latch|cpp.counting_semaphore|cpp.binary_semaphore|cpp.atomic_flag|cpp.atomic_bool|cpp.atomic_char|cpp.atomic_schar|cpp.atomic_uchar|cpp.atomic_short|cpp.atomic_ushort|cpp.atomic_int|cpp.atomic_uint|cpp.atomic_long|cpp.atomic_ulong|cpp.atomic_llong|cpp.atomic_ullong|cpp.atomic_wchar_t|cpp.atomic_char8_t|cpp.atomic_char16_t|cpp.atomic_char32_t|cpp.atomic_int8_t|cpp.atomic_uint8_t|cpp.atomic_int16_t|cpp.atomic_uint16_t|cpp.atomic_int32_t|cpp.atomic_uint32_t|cpp.atomic_int64_t|cpp.atomic_uint64_t|cpp.atomic_int_least8_t|cpp.atomic_uint_least8_t|cpp.atomic_int_least16_t|cpp.atomic_uint_least16_t|cpp.atomic_int_least32_t|cpp.atomic_uint_least32_t|cpp.atomic_int_least64_t|cpp.atomic_uint_least64_t|cpp.atomic_int_fast8_t|cpp.atomic_uint_fast8_t|cpp.atomic_int_fast16_t|cpp.atomic_uint_fast16_t|cpp.atomic_int_fast32_t|cpp.atomic_uint_fast32_t|cpp.atomic_int_fast64_t|cpp.atomic_uint_fast64_t|cpp.atomic_intptr_t|cpp.atomic_uintptr_t|cpp.atomic_size_t|cpp.atomic_ptrdiff_t|cpp.atomic_intmax_t|cpp.atomic_uintmax_t)\\b"
+              "match": "\\b(accessor|json_name|cpp.name|java.name|py.name|js.name|go.name|php.name|rb.name|csharp.name|swift.name|rust.name|scala.name|kotlin.name|dart.name|lua.name|perl.name|haskell.name|elixir.name|clojure.name|erlang.name|nim.name|zig.name|v.name|odin.name|crystal.name|d.name|groovy.name|julia.name|r.name|matlab.name|fortran.name|pascal.name|ada.name|objc.name|asm.name|llvm.name|wasm.name|spir.name|hlsl.name|glsl.name|msl.name|cuda.name|opencl.name|vulkan.name|metal.name|opengl.name|directx.name|cpp.virtual|java.annotations|cpp.include|cpp.type|cpp.ref_type|cpp.container_type|cpp.getter|cpp.setter|cpp.field|cpp.methods|cpp.allocator|cpp.copy|cpp.equals|cpp.hash|cpp.to_string|cpp.ostream|cpp.istream|cpp.serializable|cpp.bean|cpp.final|cpp.exception|cpp.enum|cpp.union|cpp.struct|cpp.service|cpp.const|cpp.typedef|cpp.namespace|cpp.package|cpp.header|cpp.out|cpp.ref|cpp.unique_ptr|cpp.shared_ptr|cpp.weak_ptr|cpp.optional|cpp.required|cpp.default_value|cpp.adapter|cpp.marshal|cpp.size|cpp.reserved|cpp.deprecated|cpp.experimental|cpp.internal|cpp.private|cpp.protected|cpp.public|cpp.static|cpp.abstract|cpp.interface|cpp.template|cpp.generic|cpp.specialization|cpp.overload|cpp.override|cpp.sealed|cpp.immutable|cpp.mutable|cpp.thread_safe|cpp.not_thread_safe|cpp.guarded_by|cpp.acquired_after|cpp.acquired_before|cpp.return_pointer|cpp.return_reference|cpp.return_value|cpp.param|cpp.throws|cpp.nothrow|cpp.noexcept|cpp.fallthrough|cpp.nodiscard|cpp.maybe_unused|cpp.likely|cpp.unlikely|cpp.assume|cpp.assert|cpp.static_assert|cpp.constexpr|cpp.consteval|cpp.constinit|cpp.inline|cpp.no_inline|cpp.force_inline|cpp.weak|cpp.strong|cpp.used|cpp.unused|cpp.retain|cpp.release|cpp.bridge|cpp.callback|cpp.event|cpp.property|cpp.indexer|cpp.operator|cpp.conversion|cpp.iterator|cpp.range|cpp.container|cpp.algorithm|cpp.functional|cpp.thread|cpp.mutex|cpp.lock|cpp.condition_variable|cpp.atomic|cpp.memory|cpp.smart_ptr|cpp.string|cpp.vector|cpp.list|cpp.deque|cpp.set|cpp.map|cpp.unordered_set|cpp.unordered_map|cpp.array|cpp.tuple|cpp.pair|cpp.variant|cpp.any|cpp.function|cpp.bind|cpp.reference_wrapper|cpp.memory_resource|cpp.polymorphic_allocator|cpp.deleter|cpp.cloner|cpp.comparator|cpp.hasher|cpp.equal_to|cpp.less|cpp.greater|cpp.plus|cpp.minus|cpp.multiplies|cpp.divides|cpp.modulus|cpp.negate|cpp.logical_and|cpp.logical_or|cpp.logical_not|cpp.bit_and|cpp.bit_or|cpp.bit_xor|cpp.bit_not|cpp.shift_left|cpp.shift_right|cpp.unary_plus|cpp.unary_minus|cpp.dereference|cpp.address_of|cpp.subscript|cpp.call|cpp.comma|cpp.ternary|cpp.cast|cpp.const_cast|cpp.static_cast|cpp.dynamic_cast|cpp.reinterpret_cast|cpp.new|cpp.delete|cpp.new_array|cpp.delete_array|cpp.malloc|cpp.free|cpp.calloc|cpp.realloc|cpp.memcpy|cpp.memmove|cpp.memset|cpp.memcmp|cpp.strcpy|cpp.strncpy|cpp.strcat|cpp.strncat|cpp.strcmp|cpp.strncmp|cpp.strlen|cpp.strchr|cpp.strrchr|cpp.strstr|cpp.strtok|cpp.sprintf|cpp.sscanf|cpp.fprintf|cpp.fscanf|cpp.printf|cpp.scanf|cpp.cout|cpp.cin|cpp.cerr|cpp.clog|cpp.endl|cpp.flush|cpp.dec|cpp.hex|cpp.oct|cpp.fixed|cpp.scientific|cpp.defaultfloat|cpp.boolalpha|cpp.noboolalpha|cpp.showbase|cpp.noshowbase|cpp.showpoint|cpp.noshowpoint|cpp.showpos|cpp.noshowpos|cpp.skipws|cpp.noskipws|cpp.uppercase|cpp.nouppercase|cpp.left|cpp.right|cpp.setfill|cpp.setprecision|cpp.setw|cpp.resetiosflags|cpp.setiosflags|cpp.unitbuf|cpp.nounitbuf|cpp.adjustfield|cpp.basefield|cpp.floatfield|cpp.errc|cpp.io_errc|cpp.stream_errc|cpp future_errc|cpp.condition_variable_any|cpp.stop_token|cpp.stop_source|cpp.jthread|cpp.barrier|cpp.latch|cpp.counting_semaphore|cpp.binary_semaphore|cpp.atomic_flag|cpp.atomic_bool|cpp.atomic_char|cpp.atomic_schar|cpp.atomic_uchar|cpp.atomic_short|cpp.atomic_ushort|cpp.atomic_int|cpp.atomic_uint|cpp.atomic_long|cpp.atomic_ulong|cpp.atomic_llong|cpp.atomic_ullong|cpp.atomic_wchar_t|cpp.atomic_char8_t|cpp.atomic_char16_t|cpp.atomic_char32_t|cpp.atomic_int8_t|cpp.atomic_uint8_t|cpp.atomic_int16_t|cpp.atomic_uint16_t|cpp.atomic_int32_t|cpp.atomic_uint32_t|cpp.atomic_int64_t|cpp.atomic_uint64_t|cpp.atomic_int_least8_t|cpp.atomic_uint_least8_t|cpp.atomic_int_least16_t|cpp.atomic_uint_least16_t|cpp.atomic_int_least32_t|cpp.atomic_uint_least32_t|cpp.atomic_int_least64_t|cpp.atomic_uint_least64_t|cpp.atomic_int_fast8_t|cpp.atomic_uint_fast8_t|cpp.atomic_int_fast16_t|cpp.atomic_uint_fast16_t|cpp.atomic_int_fast32_t|cpp.atomic_uint_fast32_t|cpp.atomic_int_fast64_t|cpp.atomic_uint_fast64_t|cpp.atomic_intptr_t|cpp.atomic_uintptr_t|cpp.atomic_size_t|cpp.atomic_ptrdiff_t|cpp.atomic_intmax_t|cpp.atomic_uintmax_t)\\b"
             },
             {
               "include": "#nested_parens"
@@ -117,6 +120,35 @@
               "include": "#annotations"
             }
           ]
+        }
+      ]
+    },
+    "namespace-definitions": {
+      "patterns": [
+        {
+          "name": "meta.namespace.thrift",
+          "match": "\\b(namespace)\\s+([a-zA-Z_\\*\\.]+)\\s+([a-zA-Z_\\.][a-zA-Z0-9_\\.]*)\\s*(.*)$",
+          "captures": {
+            "1": {
+              "name": "keyword.other.thrift"
+            },
+            "2": {
+              "name": "keyword.other.namespace.thrift"
+            },
+            "3": {
+              "name": "entity.name.namespace.thrift"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#annotations"
+                },
+                {
+                  "include": "#comments"
+                }
+              ]
+            }
+          }
         }
       ]
     },
@@ -140,22 +172,22 @@
         },
         {
           "name": "keyword.other.thrift",
-          "match": "\\b(stream|sink|interaction|performs|c_glib|cpp|delphi|haxe|go|java|js|lua|netstd|perl|php|py|py\\.twisted|rb|st|xsd|BEGIN|END|__CLASS__|__DIR__|__FILE__|__FUNCTION__|__LINE__|__METHOD__|__NAMESPACE__|abstract|alias|and|args|as|assert|begin|break|case|catch|class|clone|continue|declare|def|default|delete|do|dynamic|else|elsif|ensure|except|exec|finally|for|foreach|function|global|if|implements|import|in|inline|instanceof|interface|is|lambda|module|native|new|next|not|or|package|private|protected|public|raise|redo|rescue|retry|return|self|sizeof|static|super|switch|synchronized|then|this|throw|transient|try|undef|unless|until|use|var|virtual|volatile|when|while|with|xor|yield)\\b"
+          "match": "\\b(c_glib|cpp|delphi|haxe|go|java|js|lua|netstd|perl|php|py|py\\.twisted|rb|st|xsd|BEGIN|END|__CLASS__|__DIR__|__FILE__|__FUNCTION__|__LINE__|__METHOD__|__NAMESPACE__|abstract|alias|and|args|as|assert|begin|break|case|catch|class|clone|continue|declare|def|default|delete|do|dynamic|else|elsif|ensure|except|exec|finally|for|foreach|function|global|if|implements|import|in|inline|instanceof|interface|is|lambda|module|native|new|next|not|or|package|private|protected|public|raise|redo|rescue|retry|return|self|sizeof|static|super|switch|synchronized|then|this|throw|try|undef|unless|until|use|var|virtual|when|while|with|xor|yield)\\b"
         },
         {
           "name": "storage.modifier.thrift",
-          "match": "\\b(async|oneway|stream|sink|interaction|performs|reference|required|optional|readonly|final|transient|volatile|native)\\b"
+          "match": "\\b(async|oneway|stream|sink|interaction|performs|reference|required|optional|readonly|final|native|transient|volatile)\\b"
         }
       ]
     },
     "types": {
       "patterns": [
         {
-          "name": "support.type.primitive.thrift",
-          "match": "\\b(void|bool|byte|i8|i16|i32|i64|double|string|binary|uuid|senum|stream|sink)\\b"
+          "name": "storage.type.thrift",
+          "match": "\\b(void|bool|byte|i8|i16|i32|i64|double|string|binary|uuid|slist|senum|stream|sink)\\b"
         },
         {
-          "name": "support.type.primitive.thrift",
+          "name": "storage.type.thrift",
           "match": "\\b(map|list|set)\\b"
         },
         {
@@ -163,7 +195,7 @@
           "match": "\\b[A-Z][a-zA-Z0-9_]*\\b"
         },
         {
-          "name": "entity.name.type.namespace.thrift",
+          "name": "entity.name.type.thrift",
           "match": "\\b[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*\\b"
         }
       ]
@@ -174,7 +206,7 @@
           "begin": "\\b(map)\\s*<",
           "beginCaptures": {
             "1": {
-              "name": "support.type.primitive.thrift"
+              "name": "storage.type.thrift"
             }
           },
           "end": ">",
@@ -186,7 +218,7 @@
               "include": "#nested-types"
             },
             {
-              "name": "entity.name.type.namespace.thrift",
+              "name": "entity.name.type.thrift",
               "match": "[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*"
             },
             {
@@ -201,7 +233,7 @@
           "begin": "\\b(set|list)\\s*<",
           "beginCaptures": {
             "1": {
-              "name": "support.type.primitive.thrift"
+              "name": "storage.type.thrift"
             }
           },
           "end": ">",
@@ -213,7 +245,7 @@
               "include": "#nested-types"
             },
             {
-              "name": "entity.name.type.namespace.thrift",
+              "name": "entity.name.type.thrift",
               "match": "[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*"
             },
             {
@@ -222,10 +254,10 @@
           ]
         },
         {
-          "begin": "\\b(senum|stream|sink)\\s*<",
+          "begin": "\\b(senum|slist|stream|sink)\\s*<",
           "beginCaptures": {
             "1": {
-              "name": "support.type.primitive.thrift"
+              "name": "storage.type.thrift"
             }
           },
           "end": ">",
@@ -237,7 +269,7 @@
               "include": "#nested-types"
             },
             {
-              "name": "entity.name.type.namespace.thrift",
+              "name": "entity.name.type.thrift",
               "match": "[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*"
             },
             {
@@ -301,7 +333,7 @@
                   ]
                 },
                 {
-                  "name": "keyword.operator.map.separator.thrift",
+                  "name": "punctuation.separator.key-value.thrift",
                   "match": ":"
                 },
                 {
@@ -391,7 +423,7 @@
           "match": "\\b[A-Z][a-zA-Z0-9_]*\\b"
         },
         {
-          "name": "entity.name.function.thrift",
+          "name": "variable.other.thrift",
           "match": "\\b[a-z_][a-zA-Z0-9_]*\\b"
         }
       ]
@@ -407,8 +439,36 @@
     "operators": {
       "patterns": [
         {
+          "name": "punctuation.definition.block.thrift",
+          "match": "\\{"
+        },
+        {
+          "name": "punctuation.definition.bracket.thrift",
+          "match": "[\\[\\]]"
+        },
+        {
+          "name": "punctuation.definition.parameters.thrift",
+          "match": "[\\)]"
+        },
+        {
+          "name": "punctuation.separator.colon.thrift",
+          "match": ":"
+        },
+        {
+          "name": "punctuation.separator.semicolon.thrift",
+          "match": ";"
+        },
+        {
+          "name": "punctuation.definition.generic.thrift",
+          "match": "[<>]"
+        },
+        {
+          "name": "keyword.operator.assignment.thrift",
+          "match": "="
+        },
+        {
           "name": "keyword.operator.thrift",
-          "match": "[{}\\$\\[\\]):;=<>]"
+          "match": "[\\$]"
         }
       ]
     },
@@ -416,24 +476,30 @@
       "patterns": [
         {
           "name": "meta.struct.thrift",
-          "begin": "\\b(struct)\\s+([A-Z][a-zA-Z0-9_]*)\\s*\\{",
+          "begin": "\\b(struct)\\s+([A-Z][a-zA-Z0-9_]*)(?:\\s*(\\{)|$)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.thrift"
             },
             "2": {
               "name": "entity.name.type.thrift"
+            },
+            "3": {
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "keyword.operator.thrift"
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "patterns": [
             {
               "include": "#comments"
+            },
+            {
+              "include": "#operators"
             },
             {
               "include": "#field-definitions"
@@ -443,9 +509,6 @@
             },
             {
               "include": "#strings"
-            },
-            {
-              "include": "#operators"
             },
             {
               "include": "#punctuation-comma"
@@ -461,7 +524,7 @@
       "patterns": [
         {
           "name": "meta.service.thrift",
-          "begin": "\\b(service)\\s+([A-Z][a-zA-Z0-9_]*)\\s*(?:(extends)\\s+([A-Z][a-zA-Z0-9_]*))?\\s*\\{",
+          "begin": "\\b(service)\\s+([A-Z][a-zA-Z0-9_]*)\\s*(?:(extends)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*))?(?:\\s*(\\{)|$)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.thrift"
@@ -473,18 +536,24 @@
               "name": "keyword.other.thrift"
             },
             "4": {
-              "name": "entity.name.type.thrift"
+              "name": "entity.other.inherited-class.thrift"
+            },
+            "5": {
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "keyword.operator.thrift"
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "patterns": [
             {
               "include": "#comments"
+            },
+            {
+              "include": "#operators"
             },
             {
               "include": "#method-definitions"
@@ -500,19 +569,22 @@
       "patterns": [
         {
           "name": "meta.enum.thrift",
-          "begin": "\\b(enum)\\s+([A-Z][a-zA-Z0-9_]*)\\s*\\{",
+          "begin": "\\b(enum)\\s+([A-Z][a-zA-Z0-9_]*)(?:\\s*(\\{)|$)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.thrift"
             },
             "2": {
               "name": "entity.name.type.thrift"
+            },
+            "3": {
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "keyword.operator.thrift"
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "patterns": [
@@ -520,20 +592,23 @@
               "include": "#comments"
             },
             {
+              "include": "#operators"
+            },
+            {
               "name": "meta.enum.field.thrift",
-              "match": "\\s*([A-Z_][A-Z0-9_]*)\\s*(=)\\s*(-?[0-9]+)\\s*(,)?",
+              "match": "\\s*([A-Z_][A-Z0-9_]*)(?:\\s*(=)\\s*(-?[0-9]+))?\\s*(,)?",
               "captures": {
                 "1": {
                   "name": "constant.other.enum.thrift"
                 },
                 "2": {
-                  "name": "keyword.operator.thrift"
+                  "name": "keyword.operator.assignment.thrift"
                 },
                 "3": {
                   "name": "constant.numeric.thrift"
                 },
                 "4": {
-                  "name": "keyword.operator.thrift"
+                  "name": "punctuation.separator.comma.thrift"
                 }
               }
             },
@@ -548,24 +623,30 @@
       "patterns": [
         {
           "name": "meta.exception.thrift",
-          "begin": "\\b(exception)\\s+([A-Z][a-zA-Z0-9_]*)\\s*\\{",
+          "begin": "\\b(exception)\\s+([A-Z][a-zA-Z0-9_]*)(?:\\s*(\\{)|$)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.thrift"
             },
             "2": {
               "name": "entity.name.type.thrift"
+            },
+            "3": {
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "keyword.operator.thrift"
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "patterns": [
             {
               "include": "#comments"
+            },
+            {
+              "include": "#operators"
             },
             {
               "include": "#field-definitions"
@@ -575,9 +656,6 @@
             },
             {
               "include": "#strings"
-            },
-            {
-              "include": "#operators"
             },
             {
               "include": "#punctuation-comma"
@@ -593,24 +671,30 @@
       "patterns": [
         {
           "name": "meta.union.thrift",
-          "begin": "\\b(union)\\s+([A-Z][a-zA-Z0-9_]*)\\s*\\{",
+          "begin": "\\b(union)\\s+([A-Z][a-zA-Z0-9_]*)(?:\\s*(\\{)|$)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.thrift"
             },
             "2": {
               "name": "entity.name.type.thrift"
+            },
+            "3": {
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "keyword.operator.thrift"
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "patterns": [
             {
               "include": "#comments"
+            },
+            {
+              "include": "#operators"
             },
             {
               "include": "#field-definitions"
@@ -620,9 +704,6 @@
             },
             {
               "include": "#strings"
-            },
-            {
-              "include": "#operators"
             },
             {
               "include": "#punctuation-comma"
@@ -638,15 +719,19 @@
       "patterns": [
         {
           "name": "meta.const.thrift",
-          "match": "\\b(const)\\s+([a-zA-Z_][a-zA-Z0-9_<>, ]*)\\s+([A-Z_][A-Z0-9_]*)\\s*(=)\\s*(.*)$",
+          "match": "\\b(const)\\s+([a-zA-Z_][a-zA-Z0-9_<>, .]*)\\s+([A-Z_][A-Z0-9_]*)\\s*(=)\\s*(.*)$",
           "captures": {
             "1": {
               "name": "storage.type.thrift"
             },
             "2": {
               "patterns": [
-                { "include": "#types" },
-                { "include": "#nested-types" }
+                {
+                  "include": "#types"
+                },
+                {
+                  "include": "#nested-types"
+                }
               ]
             },
             "3": {
@@ -731,7 +816,7 @@
           "end": "\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
           "endCaptures": {
             "1": {
-              "name": "variable.other.thrift"
+              "name": "variable.other.member.thrift"
             }
           },
           "patterns": [
@@ -752,134 +837,137 @@
       ]
     },
     "method-definitions": {
-    "patterns": [
-      {
-        "name": "meta.method.definition.thrift",
-        "begin": "\\s*(oneway\\s+)?(?:(stream|sink)\\s+<([^>]+)>\\s+)?([a-zA-Z_][a-zA-Z0-9_<>, ]*)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(",
-        "beginCaptures": {
-          "1": {
-            "name": "storage.modifier.thrift"
+      "patterns": [
+        {
+          "name": "meta.method.definition.thrift",
+          "begin": "\\s*(oneway\\s+)?(?:(stream|sink)\\s+<([^>]+)>\\s+)?([a-zA-Z_][a-zA-Z0-9_<>, .]*)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.modifier.thrift"
+            },
+            "2": {
+              "name": "storage.type.thrift"
+            },
+            "3": {
+              "patterns": [
+                {
+                  "include": "#types"
+                },
+                {
+                  "include": "#nested-types"
+                }
+              ]
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#types"
+                },
+                {
+                  "include": "#nested-types"
+                }
+              ]
+            },
+            "5": {
+              "name": "entity.name.function.thrift"
+            }
           },
-          "2": {
-            "name": "support.type.primitive.thrift"
+          "end": "\\)\\s*(?:(throws)\\s*\\(([^)]*)\\))?\\s*(,)?",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.other.thrift"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#method-parameters"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.separator.comma.thrift"
+            }
           },
-          "3": {
-            "patterns": [
-              {
-                "include": "#types"
-              },
-              {
-                "include": "#nested-types"
-              }
-            ]
-          },
-          "4": {
-            "patterns": [
-              {
-                "include": "#types"
-              },
-              {
-                "include": "#nested-types"
-              }
-            ]
-          },
-          "5": {
-            "name": "entity.name.function.thrift"
-          }
+          "patterns": [
+            {
+              "include": "#method-parameters"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
         },
-        "end": "\\)\\s*(?:(throws)\\s*\\(([^)]*)\\))?\\s*(,)?",
-        "endCaptures": {
-          "1": {
-            "name": "keyword.other.thrift"
+        {
+          "name": "meta.method.thrift",
+          "begin": "\\s*(?=[a-zA-Z_<(])",
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.parameters.thrift"
+            }
           },
-          "2": {
-            "patterns": [
-              {
-                "include": "#method-parameters"
-              }
-            ]
-          },
-          "3": {
-            "name": "punctuation.separator.comma.thrift"
-          }
-        },
-        "patterns": [
-          {
-            "include": "#method-parameters"
-          },
-          {
-            "include": "#comments"
-          }
-        ]
-      },
-      {
-        "name": "meta.method.thrift",
-        "begin": "\\s*",
-        "end": "\\)",
-        "endCaptures": {
-          "0": {
-            "name": "keyword.operator.thrift"
-          }
-        },
-        "patterns": [
-          {
-            "include": "#method-parameters"
-          },
-          {
-            "include": "#types"
-          },
-          {
-            "include": "#keywords"
-          },
-          {
-            "name": "meta.method.returns.thrift",
-            "match": "\\s*(throws)\\s*\\(",
-            "captures": {
-              "1": {
-                "name": "keyword.other.thrift"
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#method-parameters"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "name": "meta.method.returns.thrift",
+              "match": "\\s*(throws)\\s*\\(",
+              "captures": {
+                "1": {
+                  "name": "keyword.other.thrift"
+                }
               }
             }
-          }
-        ]
-      }
-    ]
-  },
-  "method-parameters": {
-    "patterns": [
-      {
-        "name": "meta.parameter.thrift",
-        "begin": "\\s*([0-9]+)\\s*:\\s*",
-        "beginCaptures": {
-          "1": {
-            "name": "constant.numeric.thrift"
-          }
+          ]
+        }
+      ]
+    },
+    "method-parameters": {
+      "patterns": [
+        {
+          "name": "meta.parameter.thrift",
+          "begin": "\\s*([0-9]+)\\s*:\\s*",
+          "beginCaptures": {
+            "1": {
+              "name": "constant.numeric.thrift"
+            }
+          },
+          "end": "\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*(,)?",
+          "endCaptures": {
+            "1": {
+              "name": "variable.parameter.thrift"
+            },
+            "2": {
+              "name": "punctuation.separator.comma.thrift"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#nested-types"
+            },
+            {
+              "include": "#punctuation-comma"
+            }
+          ]
         },
-        "end": "\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*(,)?",
-        "endCaptures": {
-          "1": {
-            "name": "variable.other.thrift"
-          },
-          "2": {
-            "name": "keyword.operator.thrift"
-          }
-        },
-        "patterns": [
-          {
-            "include": "#types"
-          },
-          {
-            "include": "#nested-types"
-          },
-          {
-            "include": "#punctuation-comma"
-          }
-        ]
-      },
-      {
-        "include": "#comments"
-      }
-    ]
-  }
+        {
+          "include": "#comments"
+        }
+      ]
+    }
   },
   "scopeName": "source.thrift"
 }

--- a/tests/src/test-grammar-tokenization.js
+++ b/tests/src/test-grammar-tokenization.js
@@ -436,7 +436,7 @@ describe('TextMate Grammar Tokenization', () => {
             assert.ok(hasScopes(tokens, 'test', ['entity.name.namespace.thrift']),
                 'namespace name should be entity.name.namespace');
             // The URL in annotation should NOT trigger comment scope
-            const urlCommentTokens = tokens.filter(t => t.scopes.includes('comment.line.double-slash'));
+            const urlCommentTokens = tokens.filter(t => t.scopes.includes('comment.line.double-slash.thrift'));
             assert.strictEqual(urlCommentTokens.length, 0,
                 'URL // in annotation should not trigger comment scope');
             // Annotation should be recognized

--- a/tests/src/test-grammar-tokenization.js
+++ b/tests/src/test-grammar-tokenization.js
@@ -1,0 +1,447 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { Registry, INITIAL, parseRawGrammar } = require('vscode-textmate');
+const oniguruma = require('vscode-oniguruma');
+
+let grammar = null;
+
+// Helper: tokenize a list of lines and return all tokens with their scopes
+function tokenizeLines(lines) {
+    let stack = INITIAL;
+    const result = [];
+    for (const line of lines) {
+        const lineResult = grammar.tokenizeLine(line, stack);
+        stack = lineResult.ruleStack;
+        for (const t of lineResult.tokens) {
+            const text = line.substring(t.startIndex, t.endIndex);
+            if (text.trim()) {
+                result.push({ text: text.trim(), scopes: t.scopes, fullText: text });
+            }
+        }
+    }
+    return result;
+}
+
+// Helper: check if a token with given text has all given scopes
+function hasScopes(tokens, searchText, requiredScopes) {
+    const token = tokens.find(t => t.text === searchText);
+    if (!token) return false;
+    return requiredScopes.every(s => token.scopes.includes(s));
+}
+
+// Helper: get the scopes for a specific token text
+function getScopes(tokens, searchText) {
+    const token = tokens.find(t => t.text === searchText);
+    return token ? token.scopes : [];
+}
+
+// Helper: check that NO token has a given scope
+function noTokenHasScope(tokens, forbiddenScope) {
+    return !tokens.some(t => t.scopes.includes(forbiddenScope));
+}
+
+describe('TextMate Grammar Tokenization', () => {
+    before(async () => {
+        const wasmPath = path.join(require.resolve('vscode-oniguruma'), '..', 'onig.wasm');
+        const wasmBin = fs.readFileSync(wasmPath).buffer;
+        const onigLib = oniguruma.loadWASM(wasmBin).then(() => ({
+            createOnigScanner: (sources) => new oniguruma.OnigScanner(sources),
+            createOnigString: (str) => new oniguruma.OnigString(str),
+        }));
+
+        const registry = new Registry({
+            onigLib,
+            loadGrammar: async (scopeName) => {
+                if (scopeName === 'source.thrift') {
+                    const grammarPath = path.join(__dirname, '..', '..', 'syntaxes', 'thrift.tmLanguage.json');
+                    const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+                    return parseRawGrammar(grammarContent, grammarPath);
+                }
+                return null;
+            }
+        });
+
+        grammar = await registry.loadGrammar('source.thrift');
+    });
+
+    describe('Service definition tokenization', () => {
+        it('should recognize service with { on same line', () => {
+            const lines = ['service Foo {', '  void bar(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'service', ['meta.service.thrift', 'storage.type.thrift']),
+                'service keyword should have meta.service and storage.type scopes');
+            assert.ok(hasScopes(tokens, 'Foo', ['meta.service.thrift', 'entity.name.type.thrift']),
+                'service name should have entity.name.type scope');
+            assert.ok(hasScopes(tokens, 'bar', ['meta.method.definition.thrift', 'entity.name.function.thrift']),
+                'method name should have entity.name.function scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have any map constant scope');
+        });
+
+        it('should recognize service with { on next line', () => {
+            const lines = ['service ThriftTest', '{', '  void testVoid(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'service', ['meta.service.thrift', 'storage.type.thrift']),
+                'service keyword should have meta.service and storage.type scopes');
+            assert.ok(hasScopes(tokens, 'ThriftTest', ['meta.service.thrift', 'entity.name.type.thrift']),
+                'service name should have entity.name.type scope');
+            assert.ok(hasScopes(tokens, 'testVoid', ['meta.method.definition.thrift', 'entity.name.function.thrift']),
+                'method name should have entity.name.function scope even with { on next line');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have any map constant scope');
+        });
+
+        it('should recognize service extends with dotted parent name', () => {
+            const lines = ['service UserService extends shared.SharedService {',
+                '  User createUser(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'service', ['meta.service.thrift']),
+                'service should be in meta.service block');
+            assert.ok(hasScopes(tokens, 'UserService', ['meta.service.thrift', 'entity.name.type.thrift']),
+                'service name should be entity.name.type');
+            assert.ok(tokens.some(t => t.text === 'extends' && t.scopes.includes('keyword.other.thrift')),
+                'extends keyword should be keyword.other');
+            assert.ok(tokens.some(t => t.text === 'shared.SharedService' && t.scopes.includes('entity.other.inherited-class.thrift')),
+                'extends parent name should be entity.other.inherited-class per TextMate spec');
+            assert.ok(hasScopes(tokens, 'createUser', ['entity.name.function.thrift']),
+                'method name should have entity.name.function scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+
+        it('should recognize method return type with namespace-qualified name', () => {
+            const lines = ['service Foo {',
+                '  shared.MyType getItem(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'getItem', ['entity.name.function.thrift']),
+                'method name should be entity.name.function');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+    });
+
+    describe('Struct definition tokenization', () => {
+        it('should recognize struct with { on same line', () => {
+            const lines = ['struct MyStruct {', '  1: string name,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'struct', ['meta.struct.thrift', 'storage.type.thrift']),
+                'struct keyword should have meta.struct and storage.type scopes');
+            assert.ok(hasScopes(tokens, 'MyStruct', ['meta.struct.thrift', 'entity.name.type.thrift']),
+                'struct name should have entity.name.type scope');
+            assert.ok(hasScopes(tokens, 'name', ['variable.other.member.thrift']),
+                'field name should have variable.other.member scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+
+        it('should recognize struct with { on next line', () => {
+            const lines = ['struct MyStruct', '{', '  1: string name,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'struct', ['meta.struct.thrift', 'storage.type.thrift']),
+                'struct keyword should have meta.struct scope');
+            assert.ok(hasScopes(tokens, 'MyStruct', ['meta.struct.thrift', 'entity.name.type.thrift']),
+                'struct name should have entity.name.type scope');
+            assert.ok(hasScopes(tokens, 'name', ['variable.other.member.thrift']),
+                'field name should have variable.other.member scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope with { on next line');
+        });
+    });
+
+    describe('Enum definition tokenization', () => {
+        it('should recognize enum with { on next line', () => {
+            const lines = ['enum Numberz', '{', '  ONE = 1,', '  TWO,', '  THREE = 3,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'enum', ['meta.enum.thrift', 'storage.type.thrift']),
+                'enum keyword should have meta.enum and storage.type scopes');
+            assert.ok(hasScopes(tokens, 'Numberz', ['meta.enum.thrift', 'entity.name.type.thrift']),
+                'enum name should have entity.name.type scope');
+            assert.ok(hasScopes(tokens, 'ONE', ['constant.other.enum.thrift']),
+                'enum value with explicit assignment should have constant.other.enum scope');
+            assert.ok(hasScopes(tokens, 'TWO', ['constant.other.enum.thrift']),
+                'enum value without explicit assignment should have constant.other.enum scope');
+            assert.ok(hasScopes(tokens, 'THREE', ['constant.other.enum.thrift']),
+                'enum value should have constant.other.enum scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+    });
+
+    describe('Exception and union definition tokenization', () => {
+        it('should recognize exception with { on next line', () => {
+            const lines = ['exception MyException', '{', '  1: i32 errorCode,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'exception', ['meta.exception.thrift']),
+                'exception should be in meta.exception block');
+            assert.ok(hasScopes(tokens, 'errorCode', ['variable.other.member.thrift']),
+                'exception field should have variable.other.member scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+
+        it('should recognize union with { on next line', () => {
+            const lines = ['union MyUnion', '{', '  1: string name,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'union', ['meta.union.thrift']),
+                'union should be in meta.union block');
+            assert.ok(hasScopes(tokens, 'name', ['variable.other.member.thrift']),
+                'union field should have variable.other.member scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+    });
+
+    describe('Operator and punctuation scopes', () => {
+        it('should assign punctuation.definition.block to { and }', () => {
+            const lines = ['service Foo {', '  void bar(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, '{', ['punctuation.definition.block.thrift']),
+                'opening brace should be punctuation.definition.block');
+            assert.ok(hasScopes(tokens, '}', ['punctuation.definition.block.thrift']),
+                'closing brace should be punctuation.definition.block');
+        });
+
+        it('should assign correct scope to parentheses', () => {
+            const lines = ['service Foo {', '  void bar(1: string x),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            // The ( and ) inside method definition should be inside meta.method.definition
+            const openParen = tokens.find(t => t.fullText === '(');
+            const closeParen = tokens.find(t => t.fullText === ')');
+            assert.ok(openParen, 'should have opening paren token');
+            assert.ok(closeParen, 'should have closing paren token');
+        });
+
+        it('should assign keyword.operator.assignment to = in enum', () => {
+            const lines = ['enum Status', '{', '  ACTIVE = 1,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            const eqToken = tokens.find(t => t.text === '=');
+            assert.ok(eqToken, 'should have = token');
+            assert.ok(eqToken.scopes.includes('keyword.operator.assignment.thrift'),
+                '= in enum should be keyword.operator.assignment');
+        });
+
+        it('should assign punctuation.separator.comma to trailing commas', () => {
+            const lines = ['service Foo {', '  void bar(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            const commaToken = tokens.find(t => t.fullText === ',');
+            assert.ok(commaToken, 'should have comma token');
+            assert.ok(commaToken.scopes.includes('punctuation.separator.comma.thrift'),
+                'comma should be punctuation.separator.comma');
+        });
+    });
+
+    describe('Type scopes', () => {
+        it('should assign storage.type.thrift to primitive types', () => {
+            const lines = ['struct S {', '  1: i32 num,', '  2: string text,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'i32', ['storage.type.thrift']),
+                'i32 should have storage.type scope per TextMate spec');
+            assert.ok(hasScopes(tokens, 'string', ['storage.type.thrift']),
+                'string should have storage.type scope per TextMate spec');
+        });
+
+        it('should assign entity.name.type to user-defined types', () => {
+            const lines = ['struct MyType {', '  1: MyType field,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            const myTypeTokens = tokens.filter(t => t.text === 'MyType');
+            assert.ok(myTypeTokens.some(t => t.scopes.includes('entity.name.type.thrift')),
+                'user type should have entity.name.type scope');
+        });
+
+        it('should assign entity.name.type to namespace-qualified types', () => {
+            const lines = ['struct S {',
+                '  1: shared.SharedType field,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            // The namespace-qualified type should NOT have entity.name.type.namespace (we removed that)
+            assert.ok(!tokens.some(t => t.scopes.includes('entity.name.type.namespace.thrift')),
+                'should not use entity.name.type.namespace scope');
+        });
+    });
+
+    describe('Real file tokenization', () => {
+        it('should correctly tokenize apache-thrift-test.thrift service section', () => {
+            const testPath = path.join(__dirname, '..', '..', 'test-files', 'apache-thrift-test.thrift');
+            const content = fs.readFileSync(testPath, 'utf8');
+            const lines = content.split('\n');
+
+            let stack = INITIAL;
+            const serviceTokens = [];
+
+            // Find and tokenize the service section
+            for (let i = 0; i < lines.length; i++) {
+                const result = grammar.tokenizeLine(lines[i], stack);
+                stack = result.ruleStack;
+
+                // Lines around service ThriftTest (line 143, 0-indexed: 142)
+                if (i >= 141 && i <= 160) {
+                    for (const t of result.tokens) {
+                        const text = lines[i].substring(t.startIndex, t.endIndex).trim();
+                        if (text) {
+                            serviceTokens.push({ text, scopes: t.scopes, line: i + 1 });
+                        }
+                    }
+                }
+            }
+
+            // Check service is recognized
+            const serviceToken = serviceTokens.find(t => t.text === 'service');
+            assert.ok(serviceToken, 'should find service keyword token');
+            assert.ok(serviceToken.scopes.includes('meta.service.thrift'),
+                `service should have meta.service.thrift scope, got: ${JSON.stringify(serviceToken.scopes)}`);
+
+            // Check method names
+            const testVoidToken = serviceTokens.find(t => t.text === 'testVoid');
+            assert.ok(testVoidToken, 'should find testVoid method name token');
+            assert.ok(testVoidToken.scopes.includes('entity.name.function.thrift'),
+                `testVoid should have entity.name.function scope, got: ${JSON.stringify(testVoidToken.scopes)}`);
+
+            // Check no map constant scope leakage
+            assert.ok(!serviceTokens.some(t => t.scopes.includes('constant.other.map.thrift')),
+                'should not have constant.other.map.thrift scope in service section');
+        });
+
+        it('should correctly tokenize example.thrift', () => {
+            const testPath = path.join(__dirname, '..', '..', 'test-files', 'example.thrift');
+            const content = fs.readFileSync(testPath, 'utf8');
+            const lines = content.split('\n');
+
+            let stack = INITIAL;
+            const tokens = [];
+
+            for (let i = 0; i < lines.length; i++) {
+                const result = grammar.tokenizeLine(lines[i], stack);
+                stack = result.ruleStack;
+
+                for (const t of result.tokens) {
+                    const text = lines[i].substring(t.startIndex, t.endIndex).trim();
+                    if (text) {
+                        tokens.push({ text, scopes: t.scopes, line: i + 1 });
+                    }
+                }
+            }
+
+            // Verify service with extends is properly recognized
+            const serviceToken = tokens.find(t => t.text === 'service');
+            assert.ok(serviceToken, 'should find service keyword');
+            assert.ok(serviceToken.scopes.includes('meta.service.thrift'),
+                'service should be in meta.service block');
+
+            // Verify createUser method
+            const createUserToken = tokens.find(t => t.text === 'createUser');
+            assert.ok(createUserToken, 'should find createUser method name');
+            assert.ok(createUserToken.scopes.includes('entity.name.function.thrift'),
+                `createUser should have entity.name.function scope, got: ${JSON.stringify(createUserToken.scopes)}`);
+
+            // Verify no constant.other.map.thrift leakage
+            const mapScopedTokens = tokens.filter(t => t.scopes.includes('constant.other.map.thrift'));
+            // Map constants should only appear in actual const map definitions, not in service/struct
+            const badMapTokens = mapScopedTokens.filter(t => {
+                return t.text === 'createUser' || t.text === 'UserService' || t.text === 'User';
+            });
+            assert.strictEqual(badMapTokens.length, 0,
+                'service/struct tokens should not have map constant scope');
+        });
+    });
+
+    describe('Variable scope assignments', () => {
+        it('should assign variable.parameter to method parameters', () => {
+            const lines = ['service S {', '  void foo(1: string userName),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'userName', ['variable.parameter.thrift']),
+                'method parameter should have variable.parameter scope');
+        });
+
+        it('should assign variable.other.member to struct fields', () => {
+            const lines = ['struct S {', '  1: string userName,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'userName', ['variable.other.member.thrift']),
+                'struct field should have variable.other.member scope');
+        });
+
+        it('should assign variable.other.constant to const names', () => {
+            const lines = ['const i32 MAX_COUNT = 100'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'MAX_COUNT', ['variable.other.constant.thrift']),
+                'const name should have variable.other.constant scope');
+        });
+    });
+
+    describe('Namespace definition tokenization', () => {
+        it('should recognize namespace with scoped language identifier', () => {
+            const lines = ['namespace cpp.noexist ThriftTest'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'namespace', ['keyword.other.thrift']),
+                'namespace keyword should be keyword.other');
+            assert.ok(tokens.some(t => t.text === 'cpp.noexist' && t.scopes.includes('keyword.other.namespace.thrift')),
+                'scope modifier noexist should be keyword.other.namespace, not variable.other');
+            assert.ok(tokens.some(t => t.text === 'ThriftTest' && t.scopes.includes('entity.name.namespace.thrift')),
+                'namespace name should be entity.name.namespace');
+            assert.ok(!tokens.some(t => t.scopes.includes('variable.other.thrift')),
+                'should not have variable.other scope in namespace declaration');
+        });
+
+        it('should recognize namespace with wildcard scope', () => {
+            const lines = ['namespace * thrift.test'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'namespace', ['keyword.other.thrift']),
+                'namespace keyword should be keyword.other');
+            assert.ok(hasScopes(tokens, '*', ['keyword.other.namespace.thrift']),
+                'wildcard scope should be keyword.other.namespace');
+            assert.ok(tokens.some(t => t.text === 'thrift.test' && t.scopes.includes('entity.name.namespace.thrift')),
+                'namespace name should be entity.name.namespace');
+        });
+
+        it('should recognize namespace with simple language identifier', () => {
+            const lines = ['namespace java com.example.thrift'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'namespace', ['keyword.other.thrift']),
+                'namespace keyword should be keyword.other');
+            assert.ok(hasScopes(tokens, 'java', ['keyword.other.namespace.thrift']),
+                'language identifier should be keyword.other.namespace');
+            assert.ok(tokens.some(t => t.text === 'com.example.thrift' && t.scopes.includes('entity.name.namespace.thrift')),
+                'namespace name should be entity.name.namespace');
+        });
+
+        it('should handle namespace with annotation containing URL', () => {
+            const lines = ["namespace xsd test (uri = 'http://thrift.apache.org/ns/ThriftTest')"];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'namespace', ['keyword.other.thrift']),
+                'namespace keyword should be keyword.other');
+            assert.ok(hasScopes(tokens, 'xsd', ['keyword.other.namespace.thrift']),
+                'language identifier xsd should be keyword.other.namespace');
+            assert.ok(hasScopes(tokens, 'test', ['entity.name.namespace.thrift']),
+                'namespace name should be entity.name.namespace');
+            // The URL in annotation should NOT trigger comment scope
+            const urlCommentTokens = tokens.filter(t => t.scopes.includes('comment.line.double-slash'));
+            assert.strictEqual(urlCommentTokens.length, 0,
+                'URL // in annotation should not trigger comment scope');
+            // Annotation should be recognized
+            assert.ok(tokens.some(t => t.scopes.includes('meta.annotation.thrift')),
+                'namespace annotation should have meta.annotation scope');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Align TextMate grammar scopes to [official naming conventions](https://macromates.com/manual/en/language_grammars)
- Fix `{` on next line causing entire service/struct block to be misrecognized as map literal
- Fix enum fields without explicit `= value` assignment not being recognized
- Add `#namespace-definitions` pattern for proper namespace highlighting
- Add comprehensive vscode-textmate based tokenization tests (25 cases)

## Changes

### Scope Convention Alignment
- Built-in types `support.type.thrift` → `storage.type.thrift` (per spec: "the type of something, class, function, int, var...")
- Extends parent name `entity.name.type.thrift` → `entity.other.inherited-class.thrift` (per spec: "the superclass/baseclass name")
- Remove duplicate modifiers (`stream|sink|interaction|performs|transient|volatile`) from `keyword.other`, keep only in `storage.modifier`
- Add `#namespace-definitions` with `keyword.other.namespace.thrift` and `entity.name.namespace.thrift` scopes

### Multi-line Brace Tokenization
- Replace `\s*\{` with `(?:\s*(\{)|$)` in all begin regexes (struct/service/enum/exception/union) to support `{` on next line
- Move `#operators` ahead of `#constants` in inner patterns to prevent structural `{` from being matched as `constant.other.map.thrift`
- Remove `}` from `#operators` character class (end regexes now solely handle closing)

### Enum Fix
- Make `= value` part optional in enum field pattern to match fields without explicit assignment (e.g. `TWO,`)

### Namespace Fix
- Fix namespace annotation URL (e.g. `http://...`) falsely triggering `comment.line` scope

### Tests
- New `tests/src/test-grammar-tokenization.js` using vscode-textmate + Oniguruma for real tokenization verification
- 25 new test cases covering service/struct/enum/exception/union/namespace/operators/scopes

### Test Results
```
357 passing (1s)
```