### PR TITLE
fix: code review fixes — eliminate formatter state, security deps, and code cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,9 +183,15 @@
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5",
     "typescript-eslint": "^8.14.0",
-    "vscode": "^1.1.37",
     "vscode-oniguruma": "^2.0.1",
     "vscode-textmate": "^9.3.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "glob": ">=10.5.0",
+      "serialize-javascript": ">=7.0.5",
+      "diff": ">=8.0.3"
+    }
   },
   "nyc": {
     "include": [

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "pnpm run bundle",
+    "vscode:prepublish": "pnpm run compile && pnpm run bundle",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "bundle": "node build.js",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5",
     "typescript-eslint": "^8.14.0",
-    "vscode": "^1.1.37"
+    "vscode": "^1.1.37",
+    "vscode-oniguruma": "^2.0.1",
+    "vscode-textmate": "^9.3.2"
   },
   "nyc": {
     "include": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  glob: '>=10.5.0'
+  serialize-javascript: '>=7.0.5'
+  diff: '>=8.0.3'
+
 importers:
 
   .:
@@ -53,9 +58,6 @@ importers:
       typescript-eslint:
         specifier: ^8.14.0
         version: 8.59.2(eslint@9.39.4)(typescript@4.9.5)
-      vscode:
-        specifier: ^1.1.37
-        version: 1.1.37
       vscode-oniguruma:
         specifier: ^2.0.1
         version: 2.0.1
@@ -400,10 +402,6 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
@@ -446,10 +444,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@secretlint/config-creator@10.2.2':
     resolution: {integrity: sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==}
@@ -514,10 +508,6 @@ packages:
 
   '@textlint/types@15.6.0':
     resolution: {integrity: sha512-CvgYb1PiqF4BGyoZebGWzAJCZ4ChJAZ9gtWjpQIMKE4Xe2KlSwDA8m8MsiZIV321f5Ibx38BMjC1Z/2ZYP2GQg==}
-
-  '@tootallnate/once@1.1.2':
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -682,14 +672,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@4.3.0:
-    resolution: {integrity: sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==}
-    engines: {node: '>= 4.0.0'}
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -719,10 +701,6 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
 
   append-transform@2.0.0:
     resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
@@ -805,9 +783,6 @@ packages:
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
-  buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -895,9 +870,6 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
-  commander@2.15.1:
-    resolution: {integrity: sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==}
-
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
@@ -923,22 +895,6 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
-
-  debug@3.1.0:
-    resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -992,16 +948,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  diff@3.5.0:
-    resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==}
-    engines: {node: '>=0.3.1'}
-
-  diff@4.0.4:
-    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
-    engines: {node: '>=0.3.1'}
-
-  diff@7.0.0:
-    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dom-serializer@2.0.0:
@@ -1021,9 +969,6 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -1036,9 +981,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -1081,12 +1023,6 @@ packages:
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
-  es6-promise@4.2.8:
-    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
-
-  es6-promisify@5.0.0:
-    resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
-
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
@@ -1095,10 +1031,6 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1240,9 +1172,6 @@ packages:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -1277,22 +1206,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    hasBin: true
-
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
-
-  glob@7.1.2:
-    resolution: {integrity: sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1308,14 +1226,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  growl@1.10.5:
-    resolution: {integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==}
-    engines: {node: '>=4.x'}
-
-  has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
-    engines: {node: '>=4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1337,10 +1247,6 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  he@1.1.1:
-    resolution: {integrity: sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==}
-    hasBin: true
-
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -1359,25 +1265,9 @@ packages:
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
-  http-proxy-agent@2.1.0:
-    resolution: {integrity: sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==}
-    engines: {node: '>= 4.5.0'}
-
-  http-proxy-agent@4.0.1:
-    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
-    engines: {node: '>= 6'}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
-
-  https-proxy-agent@2.2.4:
-    resolution: {integrity: sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==}
-    engines: {node: '>= 4.5.0'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1413,10 +1303,6 @@ packages:
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1511,9 +1397,6 @@ packages:
   istextorbinary@9.5.0:
     resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
     engines: {node: '>=4'}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
@@ -1695,18 +1578,12 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.0.4:
-    resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
-
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minimist@0.0.8:
-    resolution: {integrity: sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -1718,23 +1595,10 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
-  mkdirp@0.5.1:
-    resolution: {integrity: sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==}
-    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
-    hasBin: true
-
   mocha@11.7.5:
     resolution: {integrity: sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
-
-  mocha@5.2.0:
-    resolution: {integrity: sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==}
-    engines: {node: '>= 4.0.0'}
-    hasBin: true
-
-  ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1852,17 +1716,9 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -1928,9 +1784,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
   rc-config-loader@4.1.4:
     resolution: {integrity: sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==}
@@ -2022,8 +1875,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -2073,9 +1927,6 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
-  source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
-
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -2103,10 +1954,6 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -2132,10 +1979,6 @@ packages:
 
   structured-source@4.0.0:
     resolution: {integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==}
-
-  supports-color@5.4.0:
-    resolution: {integrity: sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==}
-    engines: {node: '>=4'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2286,6 +2129,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -2301,19 +2145,8 @@ packages:
   vscode-oniguruma@2.0.1:
     resolution: {integrity: sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==}
 
-  vscode-test@0.4.3:
-    resolution: {integrity: sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==}
-    engines: {node: '>=8.9.3'}
-    deprecated: This package has been renamed to @vscode/test-electron, please update to the new name
-
   vscode-textmate@9.3.2:
     resolution: {integrity: sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==}
-
-  vscode@1.1.37:
-    resolution: {integrity: sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==}
-    engines: {node: '>=8.9.3'}
-    deprecated: 'This package is deprecated in favor of @types/vscode and vscode-test. For more information please read: https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest'
-    hasBin: true
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -2346,10 +2179,6 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -2751,15 +2580,6 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@isaacs/cliui@9.0.0': {}
 
   '@istanbuljs/load-nyc-config@1.1.0':
@@ -2807,9 +2627,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@secretlint/config-creator@10.2.2':
     dependencies:
@@ -2915,8 +2732,6 @@ snapshots:
   '@textlint/types@15.6.0':
     dependencies:
       '@textlint/ast-node-types': 15.6.0
-
-  '@tootallnate/once@1.1.2': {}
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -3124,16 +2939,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@4.3.0:
-    dependencies:
-      es6-promisify: 5.0.0
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   agent-base@7.1.4: {}
 
   aggregate-error@3.1.0:
@@ -3166,8 +2971,6 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-
-  ansi-styles@6.2.3: {}
 
   append-transform@2.0.0:
     dependencies:
@@ -3246,8 +3049,6 @@ snapshots:
   buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
-
-  buffer-from@1.1.2: {}
 
   buffer@5.7.1:
     dependencies:
@@ -3349,8 +3150,6 @@ snapshots:
 
   commander@12.1.0: {}
 
-  commander@2.15.1: {}
-
   commondir@1.0.1: {}
 
   concat-map@0.0.1: {}
@@ -3376,16 +3175,6 @@ snapshots:
       nth-check: 2.1.1
 
   css-what@6.2.2: {}
-
-  debug@3.1.0(supports-color@5.4.0):
-    dependencies:
-      ms: 2.0.0
-    optionalDependencies:
-      supports-color: 5.4.0
-
-  debug@3.2.7:
-    dependencies:
-      ms: 2.1.3
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -3425,11 +3214,7 @@ snapshots:
   detect-libc@2.1.2:
     optional: true
 
-  diff@3.5.0: {}
-
-  diff@4.0.4: {}
-
-  diff@7.0.0: {}
+  diff@9.0.0: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -3455,8 +3240,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  eastasianwidth@0.2.0: {}
-
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -3468,8 +3251,6 @@ snapshots:
   electron-to-chromium@1.5.352: {}
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -3506,12 +3287,6 @@ snapshots:
 
   es6-error@4.1.1: {}
 
-  es6-promise@4.2.8: {}
-
-  es6-promisify@5.0.0:
-    dependencies:
-      es6-promise: 4.2.8
-
   esbuild@0.28.0:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.0
@@ -3542,8 +3317,6 @@ snapshots:
       '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
-
-  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3706,8 +3479,6 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fs.realpath@1.0.0: {}
-
   function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
@@ -3745,15 +3516,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.4.5:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
   glob@11.1.0:
     dependencies:
       foreground-child: 3.3.1
@@ -3762,24 +3524,6 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
-
-  glob@7.1.2:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.0.4
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   globals@14.0.0: {}
 
@@ -3795,10 +3539,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  growl@1.10.5: {}
-
-  has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
@@ -3816,8 +3556,6 @@ snapshots:
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
-
-  he@1.1.1: {}
 
   he@1.2.0: {}
 
@@ -3838,38 +3576,9 @@ snapshots:
       domutils: 3.2.2
       entities: 7.0.1
 
-  http-proxy-agent@2.1.0:
-    dependencies:
-      agent-base: 4.3.0
-      debug: 3.1.0(supports-color@5.4.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  http-proxy-agent@4.0.1:
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@2.2.4:
-    dependencies:
-      agent-base: 4.3.0
-      debug: 3.2.7
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -3903,12 +3612,8 @@ snapshots:
 
   index-to-position@1.2.0: {}
 
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
-  inherits@2.0.4: {}
+  inherits@2.0.4:
+    optional: true
 
   ini@1.3.8:
     optional: true
@@ -3995,12 +3700,6 @@ snapshots:
       binaryextensions: 6.11.0
       editions: 6.22.0
       textextensions: 6.11.0
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@4.2.3:
     dependencies:
@@ -4174,10 +3873,6 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
-  minimatch@3.0.4:
-    dependencies:
-      brace-expansion: 1.1.14
-
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.14
@@ -4185,8 +3880,6 @@ snapshots:
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.0
-
-  minimist@0.0.8: {}
 
   minimist@1.2.8:
     optional: true
@@ -4196,19 +3889,15 @@ snapshots:
   mkdirp-classic@0.5.3:
     optional: true
 
-  mkdirp@0.5.1:
-    dependencies:
-      minimist: 0.0.8
-
   mocha@11.7.5:
     dependencies:
       browser-stdout: 1.3.1
       chokidar: 4.0.3
       debug: 4.4.3(supports-color@8.1.1)
-      diff: 7.0.0
+      diff: 9.0.0
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
-      glob: 10.4.5
+      glob: 11.1.0
       he: 1.2.0
       is-path-inside: 3.0.3
       js-yaml: 4.1.1
@@ -4216,29 +3905,13 @@ snapshots:
       minimatch: 9.0.9
       ms: 2.1.3
       picocolors: 1.1.1
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       strip-json-comments: 3.1.1
       supports-color: 8.1.1
       workerpool: 9.3.4
       yargs: 17.7.2
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
-
-  mocha@5.2.0:
-    dependencies:
-      browser-stdout: 1.3.1
-      commander: 2.15.1
-      debug: 3.1.0(supports-color@5.4.0)
-      diff: 3.5.0
-      escape-string-regexp: 1.0.5
-      glob: 7.1.2
-      growl: 1.10.5
-      he: 1.1.1
-      minimatch: 3.0.4
-      mkdirp: 0.5.1
-      supports-color: 5.4.0
-
-  ms@2.0.0: {}
 
   ms@2.1.3: {}
 
@@ -4289,7 +3962,7 @@ snapshots:
       find-up: 4.1.0
       foreground-child: 2.0.0
       get-package-type: 0.1.0
-      glob: 7.2.3
+      glob: 11.1.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-hook: 3.0.0
       istanbul-lib-instrument: 4.0.3
@@ -4315,6 +3988,7 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+    optional: true
 
   open@10.2.0:
     dependencies:
@@ -4394,14 +4068,7 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-is-absolute@1.0.1: {}
-
   path-key@3.1.1: {}
-
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -4464,10 +4131,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -4524,7 +4187,7 @@ snapshots:
 
   rimraf@3.0.2:
     dependencies:
-      glob: 7.2.3
+      glob: 11.1.0
 
   run-applescript@7.1.0: {}
 
@@ -4556,9 +4219,7 @@ snapshots:
 
   semver@7.7.4: {}
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   set-blocking@2.0.0: {}
 
@@ -4618,11 +4279,6 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
-  source-map-support@0.5.21:
-    dependencies:
-      buffer-from: 1.1.2
-      source-map: 0.6.1
-
   source-map@0.6.1: {}
 
   spawn-wrap@2.0.0:
@@ -4656,12 +4312,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
-
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -4685,10 +4335,6 @@ snapshots:
   structured-source@4.0.0:
     dependencies:
       boundary: 2.0.0
-
-  supports-color@5.4.0:
-    dependencies:
-      has-flag: 3.0.0
 
   supports-color@7.2.0:
     dependencies:
@@ -4736,7 +4382,7 @@ snapshots:
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.6
-      glob: 7.2.3
+      glob: 11.1.0
       minimatch: 3.1.5
 
   text-table@0.2.0: {}
@@ -4772,7 +4418,7 @@ snapshots:
       acorn-walk: 8.3.5
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.4
+      diff: 9.0.0
       make-error: 1.3.6
       typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
@@ -4858,26 +4504,7 @@ snapshots:
 
   vscode-oniguruma@2.0.1: {}
 
-  vscode-test@0.4.3:
-    dependencies:
-      http-proxy-agent: 2.1.0
-      https-proxy-agent: 2.2.4
-    transitivePeerDependencies:
-      - supports-color
-
   vscode-textmate@9.3.2: {}
-
-  vscode@1.1.37:
-    dependencies:
-      glob: 7.2.3
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
-      mocha: 5.2.0
-      semver: 5.7.2
-      source-map-support: 0.5.21
-      vscode-test: 0.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   whatwg-encoding@3.1.1:
     dependencies:
@@ -4907,13 +4534,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
-
-  wrappy@1.0.2: {}
+  wrappy@1.0.2:
+    optional: true
 
   write-file-atomic@3.0.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,12 @@ importers:
       vscode:
         specifier: ^1.1.37
         version: 1.1.37
+      vscode-oniguruma:
+        specifier: ^2.0.1
+        version: 2.0.1
+      vscode-textmate:
+        specifier: ^9.3.2
+        version: 9.3.2
 
 packages:
 
@@ -2292,10 +2298,16 @@ packages:
     resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
     engines: {node: '>=4'}
 
+  vscode-oniguruma@2.0.1:
+    resolution: {integrity: sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==}
+
   vscode-test@0.4.3:
     resolution: {integrity: sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==}
     engines: {node: '>=8.9.3'}
     deprecated: This package has been renamed to @vscode/test-electron, please update to the new name
+
+  vscode-textmate@9.3.2:
+    resolution: {integrity: sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==}
 
   vscode@1.1.37:
     resolution: {integrity: sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==}
@@ -4844,12 +4856,16 @@ snapshots:
 
   version-range@4.15.0: {}
 
+  vscode-oniguruma@2.0.1: {}
+
   vscode-test@0.4.3:
     dependencies:
       http-proxy-agent: 2.1.0
       https-proxy-agent: 2.2.4
     transitivePeerDependencies:
       - supports-color
+
+  vscode-textmate@9.3.2: {}
 
   vscode@1.1.37:
     dependencies:

--- a/src/ast/parser.ts
+++ b/src/ast/parser.ts
@@ -1425,7 +1425,7 @@ export class ThriftParser {
 
             // Look for type references in the node content
             if (node.type === nodes.ThriftNodeType.Service) {
-                const service = node ;
+                const service = node;
                 for (const func of service.functions) {
                     // Find dependencies in function return types and argument types
                     this.addTypeDependency(ast, func.returnType, nodeDeps);
@@ -1439,12 +1439,12 @@ export class ThriftParser {
             } else if (node.type === nodes.ThriftNodeType.Struct ||
                 node.type === nodes.ThriftNodeType.Exception ||
                 node.type === nodes.ThriftNodeType.Union) {
-                const structLike = node ;
+                const structLike = node;
                 for (const field of structLike.fields) {
                     this.addTypeDependency(ast, field.fieldType, nodeDeps);
                 }
             } else if (node.type === nodes.ThriftNodeType.Const) {
-                const constNode = node ;
+                const constNode = node;
                 this.addTypeDependency(ast, constNode.valueType, nodeDeps);
             }
 

--- a/src/definition/lookup.ts
+++ b/src/definition/lookup.ts
@@ -88,7 +88,7 @@ export class DefinitionLookup {
         }
 
         if (node.type === nodes.ThriftNodeType.Document) {
-            const doc = node ;
+            const doc = node;
             if (doc.body.length > 0) {
                 for (const item of doc.body) {
                     if (!this.traverseAST(item, callback)) {
@@ -99,35 +99,35 @@ export class DefinitionLookup {
         } else if (node.type === nodes.ThriftNodeType.Struct ||
             node.type === nodes.ThriftNodeType.Union ||
             node.type === nodes.ThriftNodeType.Exception) {
-            const struct = node ;
+            const struct = node;
             for (const field of struct.fields) {
                 if (!this.traverseAST(field, callback)) {
                     return false;
                 }
             }
         } else if (node.type === nodes.ThriftNodeType.Enum) {
-            const enumNode = node ;
+            const enumNode = node;
             for (const member of enumNode.members) {
                 if (!this.traverseAST(member, callback)) {
                     return false;
                 }
             }
         } else if (node.type === nodes.ThriftNodeType.Service) {
-            const service = node ;
+            const service = node;
             for (const func of service.functions) {
                 if (!this.traverseAST(func, callback)) {
                     return false;
                 }
             }
         } else if (node.type === nodes.ThriftNodeType.Interaction) {
-            const interaction = node ;
+            const interaction = node;
             for (const func of interaction.functions) {
                 if (!this.traverseAST(func, callback)) {
                     return false;
                 }
             }
         } else if (node.type === nodes.ThriftNodeType.Function) {
-            const func = node ;
+            const func = node;
             for (const arg of func.arguments) {
                 if (!this.traverseAST(arg, callback)) {
                     return false;

--- a/src/document-symbol-provider.ts
+++ b/src/document-symbol-provider.ts
@@ -195,7 +195,7 @@ export class ThriftDocumentSymbolProvider implements vscode.DocumentSymbolProvid
                 }
             }
         } else if (node.type === nodes.ThriftNodeType.Enum) {
-            const enumNode = node ;
+            const enumNode = node;
             for (const member of enumNode.members) {
                 const childSym = this.createSymbol(member);
                 if (childSym) {
@@ -203,7 +203,7 @@ export class ThriftDocumentSymbolProvider implements vscode.DocumentSymbolProvid
                 }
             }
         } else if (node.type === nodes.ThriftNodeType.Service) {
-            const serviceNode = node ;
+            const serviceNode = node;
             for (const func of serviceNode.functions) {
                 const childSym = this.createSymbol(func);
                 if (childSym) {
@@ -211,7 +211,7 @@ export class ThriftDocumentSymbolProvider implements vscode.DocumentSymbolProvid
                 }
             }
         } else if (node.type === nodes.ThriftNodeType.Interaction) {
-            const interactionNode = node ;
+            const interactionNode = node;
             for (const func of interactionNode.functions) {
                 const childSym = this.createSymbol(func);
                 if (childSym) {

--- a/src/formatter/ast-index.ts
+++ b/src/formatter/ast-index.ts
@@ -8,7 +8,6 @@ export interface AstIndex {
     serviceStarts: Map<number, nodes.Service>;
     serviceFunctionIndex: Map<number, nodes.ThriftFunction>;
     interactionStarts: Map<number, nodes.Interaction>;
-    interactionFunctionIndex: Map<number, nodes.ThriftFunction>;
     constStarts: Map<number, nodes.Const>;
     constEnds: Map<number, number>;
 }
@@ -26,7 +25,6 @@ export function buildAstIndex(ast: nodes.ThriftDocument): AstIndex {
     const serviceStarts = new Map<number, nodes.Service>();
     const serviceFunctionIndex = new Map<number, nodes.ThriftFunction>();
     const interactionStarts = new Map<number, nodes.Interaction>();
-    const interactionFunctionIndex = new Map<number, nodes.ThriftFunction>();
     const constStarts = new Map<number, nodes.Const>();
     const constEnds = new Map<number, number>();
 
@@ -35,7 +33,7 @@ export function buildAstIndex(ast: nodes.ThriftDocument): AstIndex {
             case nodes.ThriftNodeType.Struct:
             case nodes.ThriftNodeType.Union:
             case nodes.ThriftNodeType.Exception: {
-                const structNode = node ;
+                const structNode = node;
                 structStarts.set(structNode.range.start.line, structNode);
                 structNode.fields.forEach(field => {
                     structFieldIndex.set(field.range.start.line, field);
@@ -43,7 +41,7 @@ export function buildAstIndex(ast: nodes.ThriftDocument): AstIndex {
                 break;
             }
             case nodes.ThriftNodeType.Enum: {
-                const enumNode = node ;
+                const enumNode = node;
                 enumStarts.set(enumNode.range.start.line, enumNode);
                 enumNode.members.forEach(member => {
                     enumMemberIndex.set(member.range.start.line, member);
@@ -51,7 +49,7 @@ export function buildAstIndex(ast: nodes.ThriftDocument): AstIndex {
                 break;
             }
             case nodes.ThriftNodeType.Service: {
-                const serviceNode = node ;
+                const serviceNode = node;
                 serviceStarts.set(serviceNode.range.start.line, serviceNode);
                 serviceNode.functions.forEach(fn => {
                     serviceFunctionIndex.set(fn.range.start.line, fn);
@@ -59,15 +57,12 @@ export function buildAstIndex(ast: nodes.ThriftDocument): AstIndex {
                 break;
             }
             case nodes.ThriftNodeType.Interaction: {
-                const interactionNode = node ;
+                const interactionNode = node;
                 interactionStarts.set(interactionNode.range.start.line, interactionNode);
-                interactionNode.functions.forEach(fn => {
-                    interactionFunctionIndex.set(fn.range.start.line, fn);
-                });
                 break;
             }
             case nodes.ThriftNodeType.Const: {
-                const constNode = node ;
+                const constNode = node;
                 constStarts.set(constNode.range.start.line, constNode);
                 constEnds.set(constNode.range.start.line, constNode.range.end.line);
                 break;
@@ -87,7 +82,6 @@ export function buildAstIndex(ast: nodes.ThriftDocument): AstIndex {
         serviceStarts,
         serviceFunctionIndex,
         interactionStarts,
-        interactionFunctionIndex,
         constStarts,
         constEnds
     };

--- a/src/formatter/formatter-core.ts
+++ b/src/formatter/formatter-core.ts
@@ -34,7 +34,7 @@ import {
     handleConstStartLine
 } from './line-handlers';
 import {isAnnotationStartLine, isEnumStartLine, isInteractionStartLine, isServiceStartLine, isStructStartLine} from './line-detection';
-import {formatServiceContentLine, resetServiceAnnotationDepth} from './service-content';
+import {formatServiceContentLine} from './service-content';
 import {isServiceMethodLine} from './service-method';
 import {formatStructContentLine} from './struct-content';
 import {formatSingleLineEnum, formatSingleLineService, formatSingleLineStruct} from './single-line-format';
@@ -122,8 +122,9 @@ export function formatThriftContent(
     let constBlockIndentLevel: number | null = null;
     // Track annotation block depth for top-level @Annotation{...} blocks
     let topAnnotationDepth = 0;
-
-    resetServiceAnnotationDepth();
+    // Caller-maintained annotation depths for service/interaction bodies (avoids module-level state)
+    let serviceAnnotationDepth = 0;
+    let interactionAnnotationDepth = 0;
 
     for (let i = 0; i < lines.length; i++) {
         const originalLine = lines[i];
@@ -365,10 +366,12 @@ export function formatThriftContent(
                 getServiceIndent,
                 normalizeGenericsInSignature,
                 isServiceMethod: isServiceMethodLine
-            });
+            }, serviceAnnotationDepth);
             formattedLines.push(...serviceResult.formattedLines);
+            serviceAnnotationDepth = serviceResult.annotationDepth;
             if (serviceResult.closeService) {
                 inService = false;
+                serviceAnnotationDepth = 0;
             }
             continue;
         }
@@ -379,10 +382,12 @@ export function formatThriftContent(
                 getServiceIndent,
                 normalizeGenericsInSignature,
                 isServiceMethod: isServiceMethodLine
-            });
+            }, interactionAnnotationDepth);
             formattedLines.push(...interactionResult.formattedLines);
+            interactionAnnotationDepth = interactionResult.annotationDepth;
             if (interactionResult.closeService) {
                 inInteraction = false;
+                interactionAnnotationDepth = 0;
             }
             continue;
         }

--- a/src/formatter/service-content.ts
+++ b/src/formatter/service-content.ts
@@ -49,12 +49,11 @@ export function formatServiceContentLine(
         };
     }
 
-    // Lines inside an annotation block: use net brace count to track nesting depth.
-    // This correctly handles nested {} (e.g. map literals) without premature depth reduction.
+    // Lines inside an annotation block: count net braces while skipping string
+    // literals and line comments so that `key = "value with {brace}"` or
+    // `// {` do not affect the tracked depth.
     if (annotationDepth > 0) {
-        const opens = (line.match(/\{/g) ?? []).length;
-        const closes = (line.match(/\}/g) ?? []).length;
-        const newDepth = annotationDepth + opens - closes;
+        const newDepth = annotationDepth + countNetBraces(line);
 
         if (newDepth <= 0) {
             return {
@@ -110,4 +109,35 @@ export function formatServiceContentLine(
         closeService: false,
         annotationDepth
     };
+}
+
+/**
+ * Count the net number of structural braces on a single (trimmed) line,
+ * ignoring braces that appear inside string literals or after a `//` comment.
+ */
+function countNetBraces(line: string): number {
+    let net = 0;
+    let inDouble = false;
+    let inSingle = false;
+    for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (inDouble) {
+            if (ch === '\\') { i++; continue; }
+            if (ch === '"') { inDouble = false; }
+        } else if (inSingle) {
+            if (ch === '\\') { i++; continue; }
+            if (ch === "'") { inSingle = false; }
+        } else if (ch === '"') {
+            inDouble = true;
+        } else if (ch === "'") {
+            inSingle = true;
+        } else if (ch === '/' && line[i + 1] === '/') {
+            break; // rest of line is a comment
+        } else if (ch === '{') {
+            net++;
+        } else if (ch === '}') {
+            net--;
+        }
+    }
+    return net;
 }

--- a/src/formatter/service-content.ts
+++ b/src/formatter/service-content.ts
@@ -13,14 +13,7 @@ interface ServiceContentDeps {
 interface ServiceContentResult {
     formattedLines: string[];
     closeService: boolean;
-}
-
-// Module-level state for tracking annotation block depth inside service/interaction bodies.
-// Reset at the start of each formatting run via resetServiceAnnotationDepth().
-let serviceAnnotationDepth = 0;
-
-export function resetServiceAnnotationDepth(): void {
-    serviceAnnotationDepth = 0;
+    annotationDepth: number;
 }
 
 /**
@@ -29,49 +22,59 @@ export function resetServiceAnnotationDepth(): void {
  * @param serviceIndentLevel - Base indentation level for the service.
  * @param options - Formatting options.
  * @param deps - Formatting dependencies.
- * @returns Formatting result with closeService flag.
+ * @param annotationDepth - Current annotation block nesting depth (caller-maintained).
+ * @returns Formatting result with closeService flag and updated annotationDepth.
  */
 export function formatServiceContentLine(
     line: string,
     serviceIndentLevel: number,
     options: ThriftFormattingOptions,
-    deps: ServiceContentDeps
+    deps: ServiceContentDeps,
+    annotationDepth = 0
 ): ServiceContentResult {
     if (line === '{') {
         return {
             formattedLines: [deps.getServiceIndent(serviceIndentLevel, options) + line],
-            closeService: false
+            closeService: false,
+            annotationDepth
         };
     }
 
     // Multi-line annotation block start (e.g. @MethodMetadata{)
     if (/^\s*@[A-Za-z_][A-Za-z0-9_]*\s*\{/.test(line) && !line.includes('}')) {
-        serviceAnnotationDepth++;
         return {
             formattedLines: [deps.getServiceIndent(serviceIndentLevel + 1, options) + line],
-            closeService: false
+            closeService: false,
+            annotationDepth: annotationDepth + 1
         };
     }
 
-    // Lines inside an annotation block should be indented one extra level
-    if (serviceAnnotationDepth > 0) {
-        if (line.startsWith('}')) {
-            serviceAnnotationDepth--;
+    // Lines inside an annotation block: use net brace count to track nesting depth.
+    // This correctly handles nested {} (e.g. map literals) without premature depth reduction.
+    if (annotationDepth > 0) {
+        const opens = (line.match(/\{/g) ?? []).length;
+        const closes = (line.match(/\}/g) ?? []).length;
+        const newDepth = annotationDepth + opens - closes;
+
+        if (newDepth <= 0) {
             return {
                 formattedLines: [deps.getServiceIndent(serviceIndentLevel + 1, options) + line],
-                closeService: false
+                closeService: false,
+                annotationDepth: 0
             };
         }
         return {
             formattedLines: [deps.getServiceIndent(serviceIndentLevel + 2, options) + line],
-            closeService: false
+            closeService: false,
+            annotationDepth: newDepth
         };
     }
 
     if (line.startsWith('}')) {
         return {
             formattedLines: [deps.getServiceIndent(serviceIndentLevel, options) + line],
-            closeService: true
+            closeService: true,
+            annotationDepth: 0
         };
     }
 
@@ -79,7 +82,8 @@ export function formatServiceContentLine(
         const paramIndent = deps.getServiceIndent(serviceIndentLevel + 2, options);
         return {
             formattedLines: [paramIndent + line.trim()],
-            closeService: false
+            closeService: false,
+            annotationDepth
         };
     }
 
@@ -88,19 +92,22 @@ export function formatServiceContentLine(
         const methodIndent = deps.getServiceIndent(serviceIndentLevel + 1, options);
         return {
             formattedLines: [methodIndent + normalized],
-            closeService: false
+            closeService: false,
+            annotationDepth
         };
     }
 
     if (line.trim().startsWith('/**') || line.trim().startsWith('*') || line.trim().startsWith('*/')) {
         return {
             formattedLines: [deps.getServiceIndent(serviceIndentLevel + 1, options) + line.trim()],
-            closeService: false
+            closeService: false,
+            annotationDepth
         };
     }
 
     return {
         formattedLines: [deps.getServiceIndent(serviceIndentLevel + 1, options) + line],
-        closeService: false
+        closeService: false,
+        annotationDepth
     };
 }

--- a/src/references/ast-traversal.ts
+++ b/src/references/ast-traversal.ts
@@ -21,34 +21,34 @@ export function traverseAst(
     callback(node);
 
     if (node.type === nodes.ThriftNodeType.Document) {
-        const doc = node ;
+        const doc = node;
         if (Array.isArray(doc.body)) {
             doc.body.forEach(child => traverseAst(child, callback, contextCallback));
         }
     } else if (node.type === nodes.ThriftNodeType.Struct ||
         node.type === nodes.ThriftNodeType.Union ||
         node.type === nodes.ThriftNodeType.Exception) {
-        const struct = node ;
+        const struct = node;
         if (Array.isArray(struct.fields)) {
             struct.fields.forEach(field => traverseAst(field, callback, contextCallback));
         }
     } else if (node.type === nodes.ThriftNodeType.Enum) {
-        const enumNode = node ;
+        const enumNode = node;
         if (Array.isArray(enumNode.members)) {
             enumNode.members.forEach(member => traverseAst(member, callback, contextCallback));
         }
     } else if (node.type === nodes.ThriftNodeType.Service) {
-        const service = node ;
+        const service = node;
         if (Array.isArray(service.functions)) {
             service.functions.forEach(func => traverseAst(func, callback, contextCallback));
         }
     } else if (node.type === nodes.ThriftNodeType.Interaction) {
-        const interaction = node ;
+        const interaction = node;
         if (Array.isArray(interaction.functions)) {
             interaction.functions.forEach(func => traverseAst(func, callback, contextCallback));
         }
     } else if (node.type === nodes.ThriftNodeType.Function) {
-        const func = node ;
+        const func = node;
         if (Array.isArray(func.arguments)) {
             func.arguments.forEach(arg => traverseAst(arg, callback, contextCallback));
         }

--- a/src/references/node-locator.ts
+++ b/src/references/node-locator.ts
@@ -40,7 +40,7 @@ export function findNodeAtPosition(
                 }
 
                 if (node.type === nodes.ThriftNodeType.Document) {
-                    const docNode = node ;
+                    const docNode = node;
                     if (docNode.body.length > 0) {
                         const childResult = findDeepestNode(docNode.body);
                         if (childResult) {
@@ -50,7 +50,7 @@ export function findNodeAtPosition(
                 } else if (node.type === nodes.ThriftNodeType.Struct ||
                     node.type === nodes.ThriftNodeType.Union ||
                     node.type === nodes.ThriftNodeType.Exception) {
-                    const structNode = node ;
+                    const structNode = node;
                     if (structNode.fields.length > 0) {
                         const childResult = findDeepestNode(structNode.fields);
                         if (childResult) {
@@ -58,7 +58,7 @@ export function findNodeAtPosition(
                         }
                     }
                 } else if (node.type === nodes.ThriftNodeType.Enum) {
-                    const enumNode = node ;
+                    const enumNode = node;
                     if (enumNode.members.length > 0) {
                         const childResult = findDeepestNode(enumNode.members);
                         if (childResult) {
@@ -66,7 +66,7 @@ export function findNodeAtPosition(
                         }
                     }
                 } else if (node.type === nodes.ThriftNodeType.Service) {
-                    const serviceNode = node ;
+                    const serviceNode = node;
                     if (serviceNode.functions.length > 0) {
                         const childResult = findDeepestNode(serviceNode.functions);
                         if (childResult) {
@@ -74,7 +74,7 @@ export function findNodeAtPosition(
                         }
                     }
                 } else if (node.type === nodes.ThriftNodeType.Interaction) {
-                    const interactionNode = node ;
+                    const interactionNode = node;
                     if (interactionNode.functions.length > 0) {
                         const childResult = findDeepestNode(interactionNode.functions);
                         if (childResult) {
@@ -82,7 +82,7 @@ export function findNodeAtPosition(
                         }
                     }
                 } else if (node.type === nodes.ThriftNodeType.Function) {
-                    const funcNode = node ;
+                    const funcNode = node;
                     if (funcNode.arguments.length > 0) {
                         const childResult = findDeepestNode(funcNode.arguments);
                         if (childResult) {

--- a/src/references/reference-search.ts
+++ b/src/references/reference-search.ts
@@ -52,7 +52,7 @@ export function findReferencesInDocument(
     const contextCallback = (node: nodes.ThriftNode, entering: boolean) => {
         if (node.type === nodes.ThriftNodeType.Function) {
             if (entering) {
-                currentFunction = node ;
+                currentFunction = node;
                 inFunctionArguments = false;
                 inFunctionThrows = false;
             } else {
@@ -64,7 +64,7 @@ export function findReferencesInDocument(
 
         if (node.type === nodes.ThriftNodeType.Field) {
             if (entering) {
-                const field = node ;
+                const field = node;
                 if (currentFunction !== null && currentFunction.arguments.includes(field)) {
                     inFunctionArguments = true;
                     inFunctionThrows = false;
@@ -111,7 +111,7 @@ export function findReferencesInDocument(
         }
 
         if (node.type === nodes.ThriftNodeType.Function) {
-            const func = node ;
+            const func = node;
             if (func.returnType === symbolName) {
                 references.push(createLocation(uri, func.returnTypeRange ?? func.range));
             }
@@ -122,7 +122,7 @@ export function findReferencesInDocument(
         }
 
         if (node.type === nodes.ThriftNodeType.Field) {
-            const field = node ;
+            const field = node;
             if (!inFunctionArguments) {
                 if (field.fieldType === symbolName) {
                     references.push(createLocation(uri, field.typeRange ?? field.range));

--- a/src/references/symbol-type.ts
+++ b/src/references/symbol-type.ts
@@ -85,7 +85,7 @@ export function getSymbolType(
             case nodes.ThriftNodeType.Struct:
             case nodes.ThriftNodeType.Union:
             case nodes.ThriftNodeType.Exception: {
-                const structNode = node ;
+                const structNode = node;
                 if (structNode.fields.length > 0) {
                     for (const field of structNode.fields) {
                         if (field.name === symbolName) {
@@ -102,7 +102,7 @@ export function getSymbolType(
                 break;
             }
             case nodes.ThriftNodeType.Field: {
-                const fieldNode = node ;
+                const fieldNode = node;
                 if (fieldNode.fieldType === symbolName) {
                     return 'type';
                 }
@@ -118,7 +118,7 @@ export function getSymbolType(
                 break;
             }
             case nodes.ThriftNodeType.Enum: {
-                const enumNode = node ;
+                const enumNode = node;
                 if (enumNode.members.length > 0) {
                     for (const member of enumNode.members) {
                         if (member.name === symbolName) {
@@ -129,7 +129,7 @@ export function getSymbolType(
                 break;
             }
             case nodes.ThriftNodeType.Service: {
-                const serviceNode = node ;
+                const serviceNode = node;
                 if (serviceNode.functions.length > 0) {
                     for (const func of serviceNode.functions) {
                         if (func.name === symbolName) {
@@ -146,7 +146,7 @@ export function getSymbolType(
                 break;
             }
             case nodes.ThriftNodeType.Interaction: {
-                const interactionNode = node ;
+                const interactionNode = node;
                 if (interactionNode.functions.length > 0) {
                     for (const func of interactionNode.functions) {
                         if (func.name === symbolName) {
@@ -163,7 +163,7 @@ export function getSymbolType(
                 break;
             }
             case nodes.ThriftNodeType.Function: {
-                const funcNode = node ;
+                const funcNode = node;
                 if (funcNode.returnType === symbolName) {
                     return 'type';
                 }

--- a/src/selection-range-provider.ts
+++ b/src/selection-range-provider.ts
@@ -98,7 +98,7 @@ export class ThriftSelectionRangeProvider implements vscode.SelectionRangeProvid
         const line = document.lineAt(node.range.start.line).text;
 
         if (node.type === nodes.ThriftNodeType.Field) {
-            const required = node.requiredness ?? undefined;
+            const required = node.requiredness;
             const requiredIndex = required ? line.indexOf(required) : -1;
             const requiredRange = requiredIndex >= 0 && required
                 ? new vscode.Range(node.range.start.line, requiredIndex, node.range.start.line, requiredIndex + required.length)

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -93,7 +93,7 @@ export function registerProviders(context: vscode.ExtensionContext, deps: CoreDe
     context.subscriptions.push(
         vscode.languages.registerCodeActionsProvider(
             'thrift',
-            new ThriftRefactorCodeActionProvider(deps) as vscode.CodeActionProvider,
+            new ThriftRefactorCodeActionProvider(deps),
             {
                 providedCodeActionKinds: [
                     vscode.CodeActionKind.Refactor,

--- a/src/utils/memory-monitor.ts
+++ b/src/utils/memory-monitor.ts
@@ -248,7 +248,7 @@ export class SmartMemoryMonitor {
     private peakUsage = 0;
     private errorHandler: ErrorHandler;
     private readonly MAX_HISTORY_SIZE = 100; // 保留最近100条记录
-    private readonly MEMORY_CHECK_INTERVAL = 30000; // 30秒检查一次
+    private readonly MEMORY_CHECK_INTERVAL = 120000; // 120秒检查一次
 
     // 新增的智能组件
     private trendAnalyzer: TrendAnalyzer;

--- a/src/utils/vscode-utils.ts
+++ b/src/utils/vscode-utils.ts
@@ -4,7 +4,7 @@ import {ErrorHandler} from './error-handler';
 type LocationCtor = new (uri: vscode.Uri, range: vscode.Range) => vscode.Location;
 
 const locationCtor: LocationCtor | undefined =
-    typeof vscode.Location === 'function' ? vscode.Location : undefined;
+    typeof vscode.Location === 'function' ? (vscode.Location) : undefined;
 
 /**
  * Creates a VS Code Location object in a test-compatible way.

--- a/src/workspace-symbol-provider.ts
+++ b/src/workspace-symbol-provider.ts
@@ -381,7 +381,7 @@ export function registerWorkspaceSymbolProvider(
     deps?: Partial<CoreDependencies>
 ) {
     const provider = new ThriftWorkspaceSymbolProvider(deps);
-    const disposable = vscode.languages.registerWorkspaceSymbolProvider(provider as vscode.WorkspaceSymbolProvider);
+    const disposable = vscode.languages.registerWorkspaceSymbolProvider(provider);
     context.subscriptions.push(disposable);
     context.subscriptions.push(provider); // for dispose()
 }

--- a/syntaxes/thrift.tmLanguage.json
+++ b/syntaxes/thrift.tmLanguage.json
@@ -6,6 +6,9 @@
       "include": "#comments"
     },
     {
+      "include": "#namespace-definitions"
+    },
+    {
       "include": "#const-definitions"
     },
     {
@@ -93,12 +96,12 @@
               "match": "\\b[0-9]+\\b"
             },
             {
-              "name": "constant.language.thrift",
+              "name": "constant.language.boolean.thrift",
               "match": "\\b(true|false)\\b"
             },
             {
               "name": "keyword.other.annotation.thrift",
-              "match": "\\b(accessor|json_name|cpp.name|java.name|py.name|js.name|go.name|php.name|rb.name|csharp.name|swift.name|rust.name|scala.name|kotlin.name|dart.name|lua.name|perl.name|rust.name|haskell.name|elixir.name|clojure.name|erlang.name|nim.name|zig.name|v.name|odin.name|crystal.name|d.name|groovy.name|julia.name|r.name|matlab.name|fortran.name|pascal.name|ada.name|objc.name|asm.name|llvm.name|wasm.name|spir.name|hlsl.name|glsl.name|msl.name|cuda.name|opencl.name|vulkan.name|metal.name|opengl.name|directx.name|cpp.virtual|java.annotations|cpp.include|cpp.type|cpp.ref_type|cpp.container_type|cpp.getter|cpp.setter|cpp.field|cpp.methods|cpp.allocator|cpp.copy|cpp.equals|cpp.hash|cpp.to_string|cpp.ostream|cpp.istream|cpp.serializable|cpp.bean|cpp.final|cpp.exception|cpp.enum|cpp.union|cpp.struct|cpp.service|cpp.const|cpp.typedef|cpp.namespace|cpp.include|cpp.package|cpp.header|cpp.out|cpp.ref|cpp.unique_ptr|cpp.shared_ptr|cpp.weak_ptr|cpp.optional|cpp.required|cpp.default_value|cpp.adapter|cpp.name|cpp.marshal|cpp.size|cpp.reserved|cpp.deprecated|cpp.experimental|cpp.internal|cpp.private|cpp.protected|cpp.public|cpp.static|cpp.const|cpp.virtual|cpp.abstract|cpp.interface|cpp.template|cpp.generic|cpp.specialization|cpp.overload|cpp.override|cpp.final|cpp.sealed|cpp.immutable|cpp.mutable|cpp.thread_safe|cpp.not_thread_safe|cpp.guarded_by|cpp.acquired_after|cpp.acquired_before|cpp.return_pointer|cpp.return_reference|cpp.return_value|cpp.param|cpp.throws|cpp.nothrow|cpp.noexcept|cpp.deprecated|cpp.fallthrough|cpp.nodiscard|cpp.maybe_unused|cpp.likely|cpp.unlikely|cpp.assume|cpp.assert|cpp.static_assert|cpp.constexpr|cpp.consteval|cpp.constinit|cpp.inline|cpp.no_inline|cpp.force_inline|cpp.weak|cpp.strong|cpp.used|cpp.unused|cpp.retain|cpp.release|cpp.bridge|cpp.callback|cpp.event|cpp.property|cpp.indexer|cpp.operator|cpp.conversion|cpp.iterator|cpp.range|cpp.container|cpp.algorithm|cpp.functional|cpp.thread|cpp.mutex|cpp.lock|cpp.condition_variable|cpp.atomic|cpp.memory|cpp.smart_ptr|cpp.string|cpp.vector|cpp.list|cpp.deque|cpp.set|cpp.map|cpp.unordered_set|cpp.unordered_map|cpp.array|cpp.tuple|cpp.pair|cpp.optional|cpp.variant|cpp.any|cpp.function|cpp.bind|cpp.ref|cpp.reference_wrapper|cpp.memory_resource|cpp.polymorphic_allocator|cpp.allocator|cpp.deleter|cpp.cloner|cpp.comparator|cpp.hasher|cpp.equal_to|cpp.less|cpp.greater|cpp.plus|cpp.minus|cpp.multiplies|cpp.divides|cpp.modulus|cpp.negate|cpp.logical_and|cpp.logical_or|cpp.logical_not|cpp.bit_and|cpp.bit_or|cpp.bit_xor|cpp.bit_not|cpp.shift_left|cpp.shift_right|cpp.unary_plus|cpp.unary_minus|cpp.dereference|cpp.address_of|cpp.subscript|cpp.call|cpp.comma|cpp.ternary|cpp.cast|cpp.const_cast|cpp.static_cast|cpp.dynamic_cast|cpp.reinterpret_cast|cpp.new|cpp.delete|cpp.new_array|cpp.delete_array|cpp.malloc|cpp.free|cpp.calloc|cpp.realloc|cpp.memcpy|cpp.memmove|cpp.memset|cpp.memcmp|cpp.strcpy|cpp.strncpy|cpp.strcat|cpp.strncat|cpp.strcmp|cpp.strncmp|cpp.strlen|cpp.strchr|cpp.strrchr|cpp.strstr|cpp.strtok|cpp.sprintf|cpp.sscanf|cpp.fprintf|cpp.fscanf|cpp.printf|cpp.scanf|cpp.cout|cpp.cin|cpp.cerr|cpp.clog|cpp.endl|cpp.flush|cpp.dec|cpp.hex|cpp.oct|cpp.fixed|cpp.scientific|cpp.defaultfloat|cpp.boolalpha|cpp.noboolalpha|cpp.showbase|cpp.noshowbase|cpp.showpoint|cpp.noshowpoint|cpp.showpos|cpp.noshowpos|cpp.skipws|cpp.noskipws|cpp.uppercase|cpp.nouppercase|cpp.internal|cpp.left|cpp.right|cpp.setfill|cpp.setprecision|cpp.setw|cpp.resetiosflags|cpp.setiosflags|cpp.boolalpha|cpp.noboolalpha|cpp.showbase|cpp.noshowbase|cpp.showpoint|cpp.noshowpoint|cpp.showpos|cpp.noshowpos|cpp.skipws|cpp.noskipws|cpp.uppercase|cpp.nouppercase|cpp.unitbuf|cpp.nounitbuf|cpp.adjustfield|cpp.basefield|cpp.floatfield|cpp.errc|cpp.io_errc|cpp.stream_errc|cpp future_errc|cpp.condition_variable_any|cpp.stop_token|cpp.stop_source|cpp.jthread|cpp.barrier|cpp.latch|cpp.counting_semaphore|cpp.binary_semaphore|cpp.atomic_flag|cpp.atomic_bool|cpp.atomic_char|cpp.atomic_schar|cpp.atomic_uchar|cpp.atomic_short|cpp.atomic_ushort|cpp.atomic_int|cpp.atomic_uint|cpp.atomic_long|cpp.atomic_ulong|cpp.atomic_llong|cpp.atomic_ullong|cpp.atomic_wchar_t|cpp.atomic_char8_t|cpp.atomic_char16_t|cpp.atomic_char32_t|cpp.atomic_int8_t|cpp.atomic_uint8_t|cpp.atomic_int16_t|cpp.atomic_uint16_t|cpp.atomic_int32_t|cpp.atomic_uint32_t|cpp.atomic_int64_t|cpp.atomic_uint64_t|cpp.atomic_int_least8_t|cpp.atomic_uint_least8_t|cpp.atomic_int_least16_t|cpp.atomic_uint_least16_t|cpp.atomic_int_least32_t|cpp.atomic_uint_least32_t|cpp.atomic_int_least64_t|cpp.atomic_uint_least64_t|cpp.atomic_int_fast8_t|cpp.atomic_uint_fast8_t|cpp.atomic_int_fast16_t|cpp.atomic_uint_fast16_t|cpp.atomic_int_fast32_t|cpp.atomic_uint_fast32_t|cpp.atomic_int_fast64_t|cpp.atomic_uint_fast64_t|cpp.atomic_intptr_t|cpp.atomic_uintptr_t|cpp.atomic_size_t|cpp.atomic_ptrdiff_t|cpp.atomic_intmax_t|cpp.atomic_uintmax_t)\\b"
+              "match": "\\b(accessor|json_name|cpp.name|java.name|py.name|js.name|go.name|php.name|rb.name|csharp.name|swift.name|rust.name|scala.name|kotlin.name|dart.name|lua.name|perl.name|haskell.name|elixir.name|clojure.name|erlang.name|nim.name|zig.name|v.name|odin.name|crystal.name|d.name|groovy.name|julia.name|r.name|matlab.name|fortran.name|pascal.name|ada.name|objc.name|asm.name|llvm.name|wasm.name|spir.name|hlsl.name|glsl.name|msl.name|cuda.name|opencl.name|vulkan.name|metal.name|opengl.name|directx.name|cpp.virtual|java.annotations|cpp.include|cpp.type|cpp.ref_type|cpp.container_type|cpp.getter|cpp.setter|cpp.field|cpp.methods|cpp.allocator|cpp.copy|cpp.equals|cpp.hash|cpp.to_string|cpp.ostream|cpp.istream|cpp.serializable|cpp.bean|cpp.final|cpp.exception|cpp.enum|cpp.union|cpp.struct|cpp.service|cpp.const|cpp.typedef|cpp.namespace|cpp.package|cpp.header|cpp.out|cpp.ref|cpp.unique_ptr|cpp.shared_ptr|cpp.weak_ptr|cpp.optional|cpp.required|cpp.default_value|cpp.adapter|cpp.marshal|cpp.size|cpp.reserved|cpp.deprecated|cpp.experimental|cpp.internal|cpp.private|cpp.protected|cpp.public|cpp.static|cpp.abstract|cpp.interface|cpp.template|cpp.generic|cpp.specialization|cpp.overload|cpp.override|cpp.sealed|cpp.immutable|cpp.mutable|cpp.thread_safe|cpp.not_thread_safe|cpp.guarded_by|cpp.acquired_after|cpp.acquired_before|cpp.return_pointer|cpp.return_reference|cpp.return_value|cpp.param|cpp.throws|cpp.nothrow|cpp.noexcept|cpp.fallthrough|cpp.nodiscard|cpp.maybe_unused|cpp.likely|cpp.unlikely|cpp.assume|cpp.assert|cpp.static_assert|cpp.constexpr|cpp.consteval|cpp.constinit|cpp.inline|cpp.no_inline|cpp.force_inline|cpp.weak|cpp.strong|cpp.used|cpp.unused|cpp.retain|cpp.release|cpp.bridge|cpp.callback|cpp.event|cpp.property|cpp.indexer|cpp.operator|cpp.conversion|cpp.iterator|cpp.range|cpp.container|cpp.algorithm|cpp.functional|cpp.thread|cpp.mutex|cpp.lock|cpp.condition_variable|cpp.atomic|cpp.memory|cpp.smart_ptr|cpp.string|cpp.vector|cpp.list|cpp.deque|cpp.set|cpp.map|cpp.unordered_set|cpp.unordered_map|cpp.array|cpp.tuple|cpp.pair|cpp.variant|cpp.any|cpp.function|cpp.bind|cpp.reference_wrapper|cpp.memory_resource|cpp.polymorphic_allocator|cpp.deleter|cpp.cloner|cpp.comparator|cpp.hasher|cpp.equal_to|cpp.less|cpp.greater|cpp.plus|cpp.minus|cpp.multiplies|cpp.divides|cpp.modulus|cpp.negate|cpp.logical_and|cpp.logical_or|cpp.logical_not|cpp.bit_and|cpp.bit_or|cpp.bit_xor|cpp.bit_not|cpp.shift_left|cpp.shift_right|cpp.unary_plus|cpp.unary_minus|cpp.dereference|cpp.address_of|cpp.subscript|cpp.call|cpp.comma|cpp.ternary|cpp.cast|cpp.const_cast|cpp.static_cast|cpp.dynamic_cast|cpp.reinterpret_cast|cpp.new|cpp.delete|cpp.new_array|cpp.delete_array|cpp.malloc|cpp.free|cpp.calloc|cpp.realloc|cpp.memcpy|cpp.memmove|cpp.memset|cpp.memcmp|cpp.strcpy|cpp.strncpy|cpp.strcat|cpp.strncat|cpp.strcmp|cpp.strncmp|cpp.strlen|cpp.strchr|cpp.strrchr|cpp.strstr|cpp.strtok|cpp.sprintf|cpp.sscanf|cpp.fprintf|cpp.fscanf|cpp.printf|cpp.scanf|cpp.cout|cpp.cin|cpp.cerr|cpp.clog|cpp.endl|cpp.flush|cpp.dec|cpp.hex|cpp.oct|cpp.fixed|cpp.scientific|cpp.defaultfloat|cpp.boolalpha|cpp.noboolalpha|cpp.showbase|cpp.noshowbase|cpp.showpoint|cpp.noshowpoint|cpp.showpos|cpp.noshowpos|cpp.skipws|cpp.noskipws|cpp.uppercase|cpp.nouppercase|cpp.left|cpp.right|cpp.setfill|cpp.setprecision|cpp.setw|cpp.resetiosflags|cpp.setiosflags|cpp.unitbuf|cpp.nounitbuf|cpp.adjustfield|cpp.basefield|cpp.floatfield|cpp.errc|cpp.io_errc|cpp.stream_errc|cpp future_errc|cpp.condition_variable_any|cpp.stop_token|cpp.stop_source|cpp.jthread|cpp.barrier|cpp.latch|cpp.counting_semaphore|cpp.binary_semaphore|cpp.atomic_flag|cpp.atomic_bool|cpp.atomic_char|cpp.atomic_schar|cpp.atomic_uchar|cpp.atomic_short|cpp.atomic_ushort|cpp.atomic_int|cpp.atomic_uint|cpp.atomic_long|cpp.atomic_ulong|cpp.atomic_llong|cpp.atomic_ullong|cpp.atomic_wchar_t|cpp.atomic_char8_t|cpp.atomic_char16_t|cpp.atomic_char32_t|cpp.atomic_int8_t|cpp.atomic_uint8_t|cpp.atomic_int16_t|cpp.atomic_uint16_t|cpp.atomic_int32_t|cpp.atomic_uint32_t|cpp.atomic_int64_t|cpp.atomic_uint64_t|cpp.atomic_int_least8_t|cpp.atomic_uint_least8_t|cpp.atomic_int_least16_t|cpp.atomic_uint_least16_t|cpp.atomic_int_least32_t|cpp.atomic_uint_least32_t|cpp.atomic_int_least64_t|cpp.atomic_uint_least64_t|cpp.atomic_int_fast8_t|cpp.atomic_uint_fast8_t|cpp.atomic_int_fast16_t|cpp.atomic_uint_fast16_t|cpp.atomic_int_fast32_t|cpp.atomic_uint_fast32_t|cpp.atomic_int_fast64_t|cpp.atomic_uint_fast64_t|cpp.atomic_intptr_t|cpp.atomic_uintptr_t|cpp.atomic_size_t|cpp.atomic_ptrdiff_t|cpp.atomic_intmax_t|cpp.atomic_uintmax_t)\\b"
             },
             {
               "include": "#nested_parens"
@@ -117,6 +120,35 @@
               "include": "#annotations"
             }
           ]
+        }
+      ]
+    },
+    "namespace-definitions": {
+      "patterns": [
+        {
+          "name": "meta.namespace.thrift",
+          "match": "\\b(namespace)\\s+([a-zA-Z_\\*\\.]+)\\s+([a-zA-Z_\\.][a-zA-Z0-9_\\.]*)\\s*(.*)$",
+          "captures": {
+            "1": {
+              "name": "keyword.other.thrift"
+            },
+            "2": {
+              "name": "keyword.other.namespace.thrift"
+            },
+            "3": {
+              "name": "entity.name.namespace.thrift"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#annotations"
+                },
+                {
+                  "include": "#comments"
+                }
+              ]
+            }
+          }
         }
       ]
     },
@@ -140,22 +172,22 @@
         },
         {
           "name": "keyword.other.thrift",
-          "match": "\\b(stream|sink|interaction|performs|c_glib|cpp|delphi|haxe|go|java|js|lua|netstd|perl|php|py|py\\.twisted|rb|st|xsd|BEGIN|END|__CLASS__|__DIR__|__FILE__|__FUNCTION__|__LINE__|__METHOD__|__NAMESPACE__|abstract|alias|and|args|as|assert|begin|break|case|catch|class|clone|continue|declare|def|default|delete|do|dynamic|else|elsif|ensure|except|exec|finally|for|foreach|function|global|if|implements|import|in|inline|instanceof|interface|is|lambda|module|native|new|next|not|or|package|private|protected|public|raise|redo|rescue|retry|return|self|sizeof|static|super|switch|synchronized|then|this|throw|transient|try|undef|unless|until|use|var|virtual|volatile|when|while|with|xor|yield)\\b"
+          "match": "\\b(c_glib|cpp|delphi|haxe|go|java|js|lua|netstd|perl|php|py|py\\.twisted|rb|st|xsd|BEGIN|END|__CLASS__|__DIR__|__FILE__|__FUNCTION__|__LINE__|__METHOD__|__NAMESPACE__|abstract|alias|and|args|as|assert|begin|break|case|catch|class|clone|continue|declare|def|default|delete|do|dynamic|else|elsif|ensure|except|exec|finally|for|foreach|function|global|if|implements|import|in|inline|instanceof|interface|is|lambda|module|native|new|next|not|or|package|private|protected|public|raise|redo|rescue|retry|return|self|sizeof|static|super|switch|synchronized|then|this|throw|try|undef|unless|until|use|var|virtual|when|while|with|xor|yield)\\b"
         },
         {
           "name": "storage.modifier.thrift",
-          "match": "\\b(async|oneway|stream|sink|interaction|performs|reference|required|optional|readonly|final|transient|volatile|native)\\b"
+          "match": "\\b(async|oneway|stream|sink|interaction|performs|reference|required|optional|readonly|final|native|transient|volatile)\\b"
         }
       ]
     },
     "types": {
       "patterns": [
         {
-          "name": "support.type.primitive.thrift",
-          "match": "\\b(void|bool|byte|i8|i16|i32|i64|double|string|binary|uuid|senum|stream|sink)\\b"
+          "name": "storage.type.thrift",
+          "match": "\\b(void|bool|byte|i8|i16|i32|i64|double|string|binary|uuid|slist|senum|stream|sink)\\b"
         },
         {
-          "name": "support.type.primitive.thrift",
+          "name": "storage.type.thrift",
           "match": "\\b(map|list|set)\\b"
         },
         {
@@ -163,7 +195,7 @@
           "match": "\\b[A-Z][a-zA-Z0-9_]*\\b"
         },
         {
-          "name": "entity.name.type.namespace.thrift",
+          "name": "entity.name.type.thrift",
           "match": "\\b[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*\\b"
         }
       ]
@@ -174,7 +206,7 @@
           "begin": "\\b(map)\\s*<",
           "beginCaptures": {
             "1": {
-              "name": "support.type.primitive.thrift"
+              "name": "storage.type.thrift"
             }
           },
           "end": ">",
@@ -186,7 +218,7 @@
               "include": "#nested-types"
             },
             {
-              "name": "entity.name.type.namespace.thrift",
+              "name": "entity.name.type.thrift",
               "match": "[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*"
             },
             {
@@ -201,7 +233,7 @@
           "begin": "\\b(set|list)\\s*<",
           "beginCaptures": {
             "1": {
-              "name": "support.type.primitive.thrift"
+              "name": "storage.type.thrift"
             }
           },
           "end": ">",
@@ -213,7 +245,7 @@
               "include": "#nested-types"
             },
             {
-              "name": "entity.name.type.namespace.thrift",
+              "name": "entity.name.type.thrift",
               "match": "[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*"
             },
             {
@@ -222,10 +254,10 @@
           ]
         },
         {
-          "begin": "\\b(senum|stream|sink)\\s*<",
+          "begin": "\\b(senum|slist|stream|sink)\\s*<",
           "beginCaptures": {
             "1": {
-              "name": "support.type.primitive.thrift"
+              "name": "storage.type.thrift"
             }
           },
           "end": ">",
@@ -237,7 +269,7 @@
               "include": "#nested-types"
             },
             {
-              "name": "entity.name.type.namespace.thrift",
+              "name": "entity.name.type.thrift",
               "match": "[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*"
             },
             {
@@ -301,7 +333,7 @@
                   ]
                 },
                 {
-                  "name": "keyword.operator.map.separator.thrift",
+                  "name": "punctuation.separator.key-value.thrift",
                   "match": ":"
                 },
                 {
@@ -391,7 +423,7 @@
           "match": "\\b[A-Z][a-zA-Z0-9_]*\\b"
         },
         {
-          "name": "entity.name.function.thrift",
+          "name": "variable.other.thrift",
           "match": "\\b[a-z_][a-zA-Z0-9_]*\\b"
         }
       ]
@@ -407,8 +439,36 @@
     "operators": {
       "patterns": [
         {
+          "name": "punctuation.definition.block.thrift",
+          "match": "\\{"
+        },
+        {
+          "name": "punctuation.definition.bracket.thrift",
+          "match": "[\\[\\]]"
+        },
+        {
+          "name": "punctuation.definition.parameters.thrift",
+          "match": "[\\)]"
+        },
+        {
+          "name": "punctuation.separator.colon.thrift",
+          "match": ":"
+        },
+        {
+          "name": "punctuation.separator.semicolon.thrift",
+          "match": ";"
+        },
+        {
+          "name": "punctuation.definition.generic.thrift",
+          "match": "[<>]"
+        },
+        {
+          "name": "keyword.operator.assignment.thrift",
+          "match": "="
+        },
+        {
           "name": "keyword.operator.thrift",
-          "match": "[{}\\$\\[\\]):;=<>]"
+          "match": "[\\$]"
         }
       ]
     },
@@ -416,24 +476,30 @@
       "patterns": [
         {
           "name": "meta.struct.thrift",
-          "begin": "\\b(struct)\\s+([A-Z][a-zA-Z0-9_]*)\\s*\\{",
+          "begin": "\\b(struct)\\s+([A-Z][a-zA-Z0-9_]*)(?:\\s*(\\{)|$)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.thrift"
             },
             "2": {
               "name": "entity.name.type.thrift"
+            },
+            "3": {
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "keyword.operator.thrift"
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "patterns": [
             {
               "include": "#comments"
+            },
+            {
+              "include": "#operators"
             },
             {
               "include": "#field-definitions"
@@ -443,9 +509,6 @@
             },
             {
               "include": "#strings"
-            },
-            {
-              "include": "#operators"
             },
             {
               "include": "#punctuation-comma"
@@ -461,7 +524,7 @@
       "patterns": [
         {
           "name": "meta.service.thrift",
-          "begin": "\\b(service)\\s+([A-Z][a-zA-Z0-9_]*)\\s*(?:(extends)\\s+([A-Z][a-zA-Z0-9_]*))?\\s*\\{",
+          "begin": "\\b(service)\\s+([A-Z][a-zA-Z0-9_]*)\\s*(?:(extends)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*))?(?:\\s*(\\{)|$)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.thrift"
@@ -473,18 +536,24 @@
               "name": "keyword.other.thrift"
             },
             "4": {
-              "name": "entity.name.type.thrift"
+              "name": "entity.other.inherited-class.thrift"
+            },
+            "5": {
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "keyword.operator.thrift"
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "patterns": [
             {
               "include": "#comments"
+            },
+            {
+              "include": "#operators"
             },
             {
               "include": "#method-definitions"
@@ -500,19 +569,22 @@
       "patterns": [
         {
           "name": "meta.enum.thrift",
-          "begin": "\\b(enum)\\s+([A-Z][a-zA-Z0-9_]*)\\s*\\{",
+          "begin": "\\b(enum)\\s+([A-Z][a-zA-Z0-9_]*)(?:\\s*(\\{)|$)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.thrift"
             },
             "2": {
               "name": "entity.name.type.thrift"
+            },
+            "3": {
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "keyword.operator.thrift"
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "patterns": [
@@ -520,20 +592,23 @@
               "include": "#comments"
             },
             {
+              "include": "#operators"
+            },
+            {
               "name": "meta.enum.field.thrift",
-              "match": "\\s*([A-Z_][A-Z0-9_]*)\\s*(=)\\s*(-?[0-9]+)\\s*(,)?",
+              "match": "\\s*([A-Z_][A-Z0-9_]*)(?:\\s*(=)\\s*(-?[0-9]+))?\\s*(,)?",
               "captures": {
                 "1": {
                   "name": "constant.other.enum.thrift"
                 },
                 "2": {
-                  "name": "keyword.operator.thrift"
+                  "name": "keyword.operator.assignment.thrift"
                 },
                 "3": {
                   "name": "constant.numeric.thrift"
                 },
                 "4": {
-                  "name": "keyword.operator.thrift"
+                  "name": "punctuation.separator.comma.thrift"
                 }
               }
             },
@@ -548,24 +623,30 @@
       "patterns": [
         {
           "name": "meta.exception.thrift",
-          "begin": "\\b(exception)\\s+([A-Z][a-zA-Z0-9_]*)\\s*\\{",
+          "begin": "\\b(exception)\\s+([A-Z][a-zA-Z0-9_]*)(?:\\s*(\\{)|$)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.thrift"
             },
             "2": {
               "name": "entity.name.type.thrift"
+            },
+            "3": {
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "keyword.operator.thrift"
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "patterns": [
             {
               "include": "#comments"
+            },
+            {
+              "include": "#operators"
             },
             {
               "include": "#field-definitions"
@@ -575,9 +656,6 @@
             },
             {
               "include": "#strings"
-            },
-            {
-              "include": "#operators"
             },
             {
               "include": "#punctuation-comma"
@@ -593,24 +671,30 @@
       "patterns": [
         {
           "name": "meta.union.thrift",
-          "begin": "\\b(union)\\s+([A-Z][a-zA-Z0-9_]*)\\s*\\{",
+          "begin": "\\b(union)\\s+([A-Z][a-zA-Z0-9_]*)(?:\\s*(\\{)|$)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.thrift"
             },
             "2": {
               "name": "entity.name.type.thrift"
+            },
+            "3": {
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "end": "\\}",
           "endCaptures": {
             "0": {
-              "name": "keyword.operator.thrift"
+              "name": "punctuation.definition.block.thrift"
             }
           },
           "patterns": [
             {
               "include": "#comments"
+            },
+            {
+              "include": "#operators"
             },
             {
               "include": "#field-definitions"
@@ -620,9 +704,6 @@
             },
             {
               "include": "#strings"
-            },
-            {
-              "include": "#operators"
             },
             {
               "include": "#punctuation-comma"
@@ -638,15 +719,19 @@
       "patterns": [
         {
           "name": "meta.const.thrift",
-          "match": "\\b(const)\\s+([a-zA-Z_][a-zA-Z0-9_<>, ]*)\\s+([A-Z_][A-Z0-9_]*)\\s*(=)\\s*(.*)$",
+          "match": "\\b(const)\\s+([a-zA-Z_][a-zA-Z0-9_<>, .]*)\\s+([A-Z_][A-Z0-9_]*)\\s*(=)\\s*(.*)$",
           "captures": {
             "1": {
               "name": "storage.type.thrift"
             },
             "2": {
               "patterns": [
-                { "include": "#types" },
-                { "include": "#nested-types" }
+                {
+                  "include": "#types"
+                },
+                {
+                  "include": "#nested-types"
+                }
               ]
             },
             "3": {
@@ -731,7 +816,7 @@
           "end": "\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
           "endCaptures": {
             "1": {
-              "name": "variable.other.thrift"
+              "name": "variable.other.member.thrift"
             }
           },
           "patterns": [
@@ -752,134 +837,137 @@
       ]
     },
     "method-definitions": {
-    "patterns": [
-      {
-        "name": "meta.method.definition.thrift",
-        "begin": "\\s*(oneway\\s+)?(?:(stream|sink)\\s+<([^>]+)>\\s+)?([a-zA-Z_][a-zA-Z0-9_<>, ]*)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(",
-        "beginCaptures": {
-          "1": {
-            "name": "storage.modifier.thrift"
+      "patterns": [
+        {
+          "name": "meta.method.definition.thrift",
+          "begin": "\\s*(oneway\\s+)?(?:(stream|sink)\\s+<([^>]+)>\\s+)?([a-zA-Z_][a-zA-Z0-9_<>, .]*)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.modifier.thrift"
+            },
+            "2": {
+              "name": "storage.type.thrift"
+            },
+            "3": {
+              "patterns": [
+                {
+                  "include": "#types"
+                },
+                {
+                  "include": "#nested-types"
+                }
+              ]
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#types"
+                },
+                {
+                  "include": "#nested-types"
+                }
+              ]
+            },
+            "5": {
+              "name": "entity.name.function.thrift"
+            }
           },
-          "2": {
-            "name": "support.type.primitive.thrift"
+          "end": "\\)\\s*(?:(throws)\\s*\\(([^)]*)\\))?\\s*(,)?",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.other.thrift"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#method-parameters"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.separator.comma.thrift"
+            }
           },
-          "3": {
-            "patterns": [
-              {
-                "include": "#types"
-              },
-              {
-                "include": "#nested-types"
-              }
-            ]
-          },
-          "4": {
-            "patterns": [
-              {
-                "include": "#types"
-              },
-              {
-                "include": "#nested-types"
-              }
-            ]
-          },
-          "5": {
-            "name": "entity.name.function.thrift"
-          }
+          "patterns": [
+            {
+              "include": "#method-parameters"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
         },
-        "end": "\\)\\s*(?:(throws)\\s*\\(([^)]*)\\))?\\s*(,)?",
-        "endCaptures": {
-          "1": {
-            "name": "keyword.other.thrift"
+        {
+          "name": "meta.method.thrift",
+          "begin": "\\s*(?=[a-zA-Z_<(])",
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.parameters.thrift"
+            }
           },
-          "2": {
-            "patterns": [
-              {
-                "include": "#method-parameters"
-              }
-            ]
-          },
-          "3": {
-            "name": "punctuation.separator.comma.thrift"
-          }
-        },
-        "patterns": [
-          {
-            "include": "#method-parameters"
-          },
-          {
-            "include": "#comments"
-          }
-        ]
-      },
-      {
-        "name": "meta.method.thrift",
-        "begin": "\\s*",
-        "end": "\\)",
-        "endCaptures": {
-          "0": {
-            "name": "keyword.operator.thrift"
-          }
-        },
-        "patterns": [
-          {
-            "include": "#method-parameters"
-          },
-          {
-            "include": "#types"
-          },
-          {
-            "include": "#keywords"
-          },
-          {
-            "name": "meta.method.returns.thrift",
-            "match": "\\s*(throws)\\s*\\(",
-            "captures": {
-              "1": {
-                "name": "keyword.other.thrift"
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#method-parameters"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "name": "meta.method.returns.thrift",
+              "match": "\\s*(throws)\\s*\\(",
+              "captures": {
+                "1": {
+                  "name": "keyword.other.thrift"
+                }
               }
             }
-          }
-        ]
-      }
-    ]
-  },
-  "method-parameters": {
-    "patterns": [
-      {
-        "name": "meta.parameter.thrift",
-        "begin": "\\s*([0-9]+)\\s*:\\s*",
-        "beginCaptures": {
-          "1": {
-            "name": "constant.numeric.thrift"
-          }
+          ]
+        }
+      ]
+    },
+    "method-parameters": {
+      "patterns": [
+        {
+          "name": "meta.parameter.thrift",
+          "begin": "\\s*([0-9]+)\\s*:\\s*",
+          "beginCaptures": {
+            "1": {
+              "name": "constant.numeric.thrift"
+            }
+          },
+          "end": "\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*(,)?",
+          "endCaptures": {
+            "1": {
+              "name": "variable.parameter.thrift"
+            },
+            "2": {
+              "name": "punctuation.separator.comma.thrift"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#nested-types"
+            },
+            {
+              "include": "#punctuation-comma"
+            }
+          ]
         },
-        "end": "\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*(,)?",
-        "endCaptures": {
-          "1": {
-            "name": "variable.other.thrift"
-          },
-          "2": {
-            "name": "keyword.operator.thrift"
-          }
-        },
-        "patterns": [
-          {
-            "include": "#types"
-          },
-          {
-            "include": "#nested-types"
-          },
-          {
-            "include": "#punctuation-comma"
-          }
-        ]
-      },
-      {
-        "include": "#comments"
-      }
-    ]
-  }
+        {
+          "include": "#comments"
+        }
+      ]
+    }
   },
   "scopeName": "source.thrift"
 }

--- a/tests/src/formatter/test-advanced-features-formatting.js
+++ b/tests/src/formatter/test-advanced-features-formatting.js
@@ -2,7 +2,6 @@
 const assert = require('assert');
 const vscode = require('vscode');
 const {formatThriftContent} = require('../../../out/formatter/formatter-core.js');
-const {resetServiceAnnotationDepth} = require('../../../out/formatter/service-content.js');
 
 function run() {
     const options = {insertSpaces: true, indentSize: 4, tabSize: 4};
@@ -144,7 +143,6 @@ key = "value"
     );
 
     // === Test 7: Regression - stream sink types in formatting ===
-    resetServiceAnnotationDepth();
     const streamService = `
 service StreamService {
     stream<i32> uploadData(1: string sessionId)

--- a/tests/src/test-grammar-tokenization.js
+++ b/tests/src/test-grammar-tokenization.js
@@ -436,7 +436,7 @@ describe('TextMate Grammar Tokenization', () => {
             assert.ok(hasScopes(tokens, 'test', ['entity.name.namespace.thrift']),
                 'namespace name should be entity.name.namespace');
             // The URL in annotation should NOT trigger comment scope
-            const urlCommentTokens = tokens.filter(t => t.scopes.includes('comment.line.double-slash'));
+            const urlCommentTokens = tokens.filter(t => t.scopes.includes('comment.line.double-slash.thrift'));
             assert.strictEqual(urlCommentTokens.length, 0,
                 'URL // in annotation should not trigger comment scope');
             // Annotation should be recognized

--- a/tests/src/test-grammar-tokenization.js
+++ b/tests/src/test-grammar-tokenization.js
@@ -1,0 +1,447 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { Registry, INITIAL, parseRawGrammar } = require('vscode-textmate');
+const oniguruma = require('vscode-oniguruma');
+
+let grammar = null;
+
+// Helper: tokenize a list of lines and return all tokens with their scopes
+function tokenizeLines(lines) {
+    let stack = INITIAL;
+    const result = [];
+    for (const line of lines) {
+        const lineResult = grammar.tokenizeLine(line, stack);
+        stack = lineResult.ruleStack;
+        for (const t of lineResult.tokens) {
+            const text = line.substring(t.startIndex, t.endIndex);
+            if (text.trim()) {
+                result.push({ text: text.trim(), scopes: t.scopes, fullText: text });
+            }
+        }
+    }
+    return result;
+}
+
+// Helper: check if a token with given text has all given scopes
+function hasScopes(tokens, searchText, requiredScopes) {
+    const token = tokens.find(t => t.text === searchText);
+    if (!token) return false;
+    return requiredScopes.every(s => token.scopes.includes(s));
+}
+
+// Helper: get the scopes for a specific token text
+function getScopes(tokens, searchText) {
+    const token = tokens.find(t => t.text === searchText);
+    return token ? token.scopes : [];
+}
+
+// Helper: check that NO token has a given scope
+function noTokenHasScope(tokens, forbiddenScope) {
+    return !tokens.some(t => t.scopes.includes(forbiddenScope));
+}
+
+describe('TextMate Grammar Tokenization', () => {
+    before(async () => {
+        const wasmPath = path.join(require.resolve('vscode-oniguruma'), '..', 'onig.wasm');
+        const wasmBin = fs.readFileSync(wasmPath).buffer;
+        const onigLib = oniguruma.loadWASM(wasmBin).then(() => ({
+            createOnigScanner: (sources) => new oniguruma.OnigScanner(sources),
+            createOnigString: (str) => new oniguruma.OnigString(str),
+        }));
+
+        const registry = new Registry({
+            onigLib,
+            loadGrammar: async (scopeName) => {
+                if (scopeName === 'source.thrift') {
+                    const grammarPath = path.join(__dirname, '..', '..', 'syntaxes', 'thrift.tmLanguage.json');
+                    const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+                    return parseRawGrammar(grammarContent, grammarPath);
+                }
+                return null;
+            }
+        });
+
+        grammar = await registry.loadGrammar('source.thrift');
+    });
+
+    describe('Service definition tokenization', () => {
+        it('should recognize service with { on same line', () => {
+            const lines = ['service Foo {', '  void bar(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'service', ['meta.service.thrift', 'storage.type.thrift']),
+                'service keyword should have meta.service and storage.type scopes');
+            assert.ok(hasScopes(tokens, 'Foo', ['meta.service.thrift', 'entity.name.type.thrift']),
+                'service name should have entity.name.type scope');
+            assert.ok(hasScopes(tokens, 'bar', ['meta.method.definition.thrift', 'entity.name.function.thrift']),
+                'method name should have entity.name.function scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have any map constant scope');
+        });
+
+        it('should recognize service with { on next line', () => {
+            const lines = ['service ThriftTest', '{', '  void testVoid(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'service', ['meta.service.thrift', 'storage.type.thrift']),
+                'service keyword should have meta.service and storage.type scopes');
+            assert.ok(hasScopes(tokens, 'ThriftTest', ['meta.service.thrift', 'entity.name.type.thrift']),
+                'service name should have entity.name.type scope');
+            assert.ok(hasScopes(tokens, 'testVoid', ['meta.method.definition.thrift', 'entity.name.function.thrift']),
+                'method name should have entity.name.function scope even with { on next line');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have any map constant scope');
+        });
+
+        it('should recognize service extends with dotted parent name', () => {
+            const lines = ['service UserService extends shared.SharedService {',
+                '  User createUser(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'service', ['meta.service.thrift']),
+                'service should be in meta.service block');
+            assert.ok(hasScopes(tokens, 'UserService', ['meta.service.thrift', 'entity.name.type.thrift']),
+                'service name should be entity.name.type');
+            assert.ok(tokens.some(t => t.text === 'extends' && t.scopes.includes('keyword.other.thrift')),
+                'extends keyword should be keyword.other');
+            assert.ok(tokens.some(t => t.text === 'shared.SharedService' && t.scopes.includes('entity.other.inherited-class.thrift')),
+                'extends parent name should be entity.other.inherited-class per TextMate spec');
+            assert.ok(hasScopes(tokens, 'createUser', ['entity.name.function.thrift']),
+                'method name should have entity.name.function scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+
+        it('should recognize method return type with namespace-qualified name', () => {
+            const lines = ['service Foo {',
+                '  shared.MyType getItem(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'getItem', ['entity.name.function.thrift']),
+                'method name should be entity.name.function');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+    });
+
+    describe('Struct definition tokenization', () => {
+        it('should recognize struct with { on same line', () => {
+            const lines = ['struct MyStruct {', '  1: string name,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'struct', ['meta.struct.thrift', 'storage.type.thrift']),
+                'struct keyword should have meta.struct and storage.type scopes');
+            assert.ok(hasScopes(tokens, 'MyStruct', ['meta.struct.thrift', 'entity.name.type.thrift']),
+                'struct name should have entity.name.type scope');
+            assert.ok(hasScopes(tokens, 'name', ['variable.other.member.thrift']),
+                'field name should have variable.other.member scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+
+        it('should recognize struct with { on next line', () => {
+            const lines = ['struct MyStruct', '{', '  1: string name,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'struct', ['meta.struct.thrift', 'storage.type.thrift']),
+                'struct keyword should have meta.struct scope');
+            assert.ok(hasScopes(tokens, 'MyStruct', ['meta.struct.thrift', 'entity.name.type.thrift']),
+                'struct name should have entity.name.type scope');
+            assert.ok(hasScopes(tokens, 'name', ['variable.other.member.thrift']),
+                'field name should have variable.other.member scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope with { on next line');
+        });
+    });
+
+    describe('Enum definition tokenization', () => {
+        it('should recognize enum with { on next line', () => {
+            const lines = ['enum Numberz', '{', '  ONE = 1,', '  TWO,', '  THREE = 3,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'enum', ['meta.enum.thrift', 'storage.type.thrift']),
+                'enum keyword should have meta.enum and storage.type scopes');
+            assert.ok(hasScopes(tokens, 'Numberz', ['meta.enum.thrift', 'entity.name.type.thrift']),
+                'enum name should have entity.name.type scope');
+            assert.ok(hasScopes(tokens, 'ONE', ['constant.other.enum.thrift']),
+                'enum value with explicit assignment should have constant.other.enum scope');
+            assert.ok(hasScopes(tokens, 'TWO', ['constant.other.enum.thrift']),
+                'enum value without explicit assignment should have constant.other.enum scope');
+            assert.ok(hasScopes(tokens, 'THREE', ['constant.other.enum.thrift']),
+                'enum value should have constant.other.enum scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+    });
+
+    describe('Exception and union definition tokenization', () => {
+        it('should recognize exception with { on next line', () => {
+            const lines = ['exception MyException', '{', '  1: i32 errorCode,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'exception', ['meta.exception.thrift']),
+                'exception should be in meta.exception block');
+            assert.ok(hasScopes(tokens, 'errorCode', ['variable.other.member.thrift']),
+                'exception field should have variable.other.member scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+
+        it('should recognize union with { on next line', () => {
+            const lines = ['union MyUnion', '{', '  1: string name,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'union', ['meta.union.thrift']),
+                'union should be in meta.union block');
+            assert.ok(hasScopes(tokens, 'name', ['variable.other.member.thrift']),
+                'union field should have variable.other.member scope');
+            assert.ok(noTokenHasScope(tokens, 'constant.other.map.thrift'),
+                'should not have map constant scope');
+        });
+    });
+
+    describe('Operator and punctuation scopes', () => {
+        it('should assign punctuation.definition.block to { and }', () => {
+            const lines = ['service Foo {', '  void bar(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, '{', ['punctuation.definition.block.thrift']),
+                'opening brace should be punctuation.definition.block');
+            assert.ok(hasScopes(tokens, '}', ['punctuation.definition.block.thrift']),
+                'closing brace should be punctuation.definition.block');
+        });
+
+        it('should assign correct scope to parentheses', () => {
+            const lines = ['service Foo {', '  void bar(1: string x),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            // The ( and ) inside method definition should be inside meta.method.definition
+            const openParen = tokens.find(t => t.fullText === '(');
+            const closeParen = tokens.find(t => t.fullText === ')');
+            assert.ok(openParen, 'should have opening paren token');
+            assert.ok(closeParen, 'should have closing paren token');
+        });
+
+        it('should assign keyword.operator.assignment to = in enum', () => {
+            const lines = ['enum Status', '{', '  ACTIVE = 1,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            const eqToken = tokens.find(t => t.text === '=');
+            assert.ok(eqToken, 'should have = token');
+            assert.ok(eqToken.scopes.includes('keyword.operator.assignment.thrift'),
+                '= in enum should be keyword.operator.assignment');
+        });
+
+        it('should assign punctuation.separator.comma to trailing commas', () => {
+            const lines = ['service Foo {', '  void bar(),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            const commaToken = tokens.find(t => t.fullText === ',');
+            assert.ok(commaToken, 'should have comma token');
+            assert.ok(commaToken.scopes.includes('punctuation.separator.comma.thrift'),
+                'comma should be punctuation.separator.comma');
+        });
+    });
+
+    describe('Type scopes', () => {
+        it('should assign storage.type.thrift to primitive types', () => {
+            const lines = ['struct S {', '  1: i32 num,', '  2: string text,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'i32', ['storage.type.thrift']),
+                'i32 should have storage.type scope per TextMate spec');
+            assert.ok(hasScopes(tokens, 'string', ['storage.type.thrift']),
+                'string should have storage.type scope per TextMate spec');
+        });
+
+        it('should assign entity.name.type to user-defined types', () => {
+            const lines = ['struct MyType {', '  1: MyType field,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            const myTypeTokens = tokens.filter(t => t.text === 'MyType');
+            assert.ok(myTypeTokens.some(t => t.scopes.includes('entity.name.type.thrift')),
+                'user type should have entity.name.type scope');
+        });
+
+        it('should assign entity.name.type to namespace-qualified types', () => {
+            const lines = ['struct S {',
+                '  1: shared.SharedType field,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            // The namespace-qualified type should NOT have entity.name.type.namespace (we removed that)
+            assert.ok(!tokens.some(t => t.scopes.includes('entity.name.type.namespace.thrift')),
+                'should not use entity.name.type.namespace scope');
+        });
+    });
+
+    describe('Real file tokenization', () => {
+        it('should correctly tokenize apache-thrift-test.thrift service section', () => {
+            const testPath = path.join(__dirname, '..', '..', 'test-files', 'apache-thrift-test.thrift');
+            const content = fs.readFileSync(testPath, 'utf8');
+            const lines = content.split('\n');
+
+            let stack = INITIAL;
+            const serviceTokens = [];
+
+            // Find and tokenize the service section
+            for (let i = 0; i < lines.length; i++) {
+                const result = grammar.tokenizeLine(lines[i], stack);
+                stack = result.ruleStack;
+
+                // Lines around service ThriftTest (line 143, 0-indexed: 142)
+                if (i >= 141 && i <= 160) {
+                    for (const t of result.tokens) {
+                        const text = lines[i].substring(t.startIndex, t.endIndex).trim();
+                        if (text) {
+                            serviceTokens.push({ text, scopes: t.scopes, line: i + 1 });
+                        }
+                    }
+                }
+            }
+
+            // Check service is recognized
+            const serviceToken = serviceTokens.find(t => t.text === 'service');
+            assert.ok(serviceToken, 'should find service keyword token');
+            assert.ok(serviceToken.scopes.includes('meta.service.thrift'),
+                `service should have meta.service.thrift scope, got: ${JSON.stringify(serviceToken.scopes)}`);
+
+            // Check method names
+            const testVoidToken = serviceTokens.find(t => t.text === 'testVoid');
+            assert.ok(testVoidToken, 'should find testVoid method name token');
+            assert.ok(testVoidToken.scopes.includes('entity.name.function.thrift'),
+                `testVoid should have entity.name.function scope, got: ${JSON.stringify(testVoidToken.scopes)}`);
+
+            // Check no map constant scope leakage
+            assert.ok(!serviceTokens.some(t => t.scopes.includes('constant.other.map.thrift')),
+                'should not have constant.other.map.thrift scope in service section');
+        });
+
+        it('should correctly tokenize example.thrift', () => {
+            const testPath = path.join(__dirname, '..', '..', 'test-files', 'example.thrift');
+            const content = fs.readFileSync(testPath, 'utf8');
+            const lines = content.split('\n');
+
+            let stack = INITIAL;
+            const tokens = [];
+
+            for (let i = 0; i < lines.length; i++) {
+                const result = grammar.tokenizeLine(lines[i], stack);
+                stack = result.ruleStack;
+
+                for (const t of result.tokens) {
+                    const text = lines[i].substring(t.startIndex, t.endIndex).trim();
+                    if (text) {
+                        tokens.push({ text, scopes: t.scopes, line: i + 1 });
+                    }
+                }
+            }
+
+            // Verify service with extends is properly recognized
+            const serviceToken = tokens.find(t => t.text === 'service');
+            assert.ok(serviceToken, 'should find service keyword');
+            assert.ok(serviceToken.scopes.includes('meta.service.thrift'),
+                'service should be in meta.service block');
+
+            // Verify createUser method
+            const createUserToken = tokens.find(t => t.text === 'createUser');
+            assert.ok(createUserToken, 'should find createUser method name');
+            assert.ok(createUserToken.scopes.includes('entity.name.function.thrift'),
+                `createUser should have entity.name.function scope, got: ${JSON.stringify(createUserToken.scopes)}`);
+
+            // Verify no constant.other.map.thrift leakage
+            const mapScopedTokens = tokens.filter(t => t.scopes.includes('constant.other.map.thrift'));
+            // Map constants should only appear in actual const map definitions, not in service/struct
+            const badMapTokens = mapScopedTokens.filter(t => {
+                return t.text === 'createUser' || t.text === 'UserService' || t.text === 'User';
+            });
+            assert.strictEqual(badMapTokens.length, 0,
+                'service/struct tokens should not have map constant scope');
+        });
+    });
+
+    describe('Variable scope assignments', () => {
+        it('should assign variable.parameter to method parameters', () => {
+            const lines = ['service S {', '  void foo(1: string userName),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'userName', ['variable.parameter.thrift']),
+                'method parameter should have variable.parameter scope');
+        });
+
+        it('should assign variable.other.member to struct fields', () => {
+            const lines = ['struct S {', '  1: string userName,', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'userName', ['variable.other.member.thrift']),
+                'struct field should have variable.other.member scope');
+        });
+
+        it('should assign variable.other.constant to const names', () => {
+            const lines = ['const i32 MAX_COUNT = 100'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'MAX_COUNT', ['variable.other.constant.thrift']),
+                'const name should have variable.other.constant scope');
+        });
+    });
+
+    describe('Namespace definition tokenization', () => {
+        it('should recognize namespace with scoped language identifier', () => {
+            const lines = ['namespace cpp.noexist ThriftTest'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'namespace', ['keyword.other.thrift']),
+                'namespace keyword should be keyword.other');
+            assert.ok(tokens.some(t => t.text === 'cpp.noexist' && t.scopes.includes('keyword.other.namespace.thrift')),
+                'scope modifier noexist should be keyword.other.namespace, not variable.other');
+            assert.ok(tokens.some(t => t.text === 'ThriftTest' && t.scopes.includes('entity.name.namespace.thrift')),
+                'namespace name should be entity.name.namespace');
+            assert.ok(!tokens.some(t => t.scopes.includes('variable.other.thrift')),
+                'should not have variable.other scope in namespace declaration');
+        });
+
+        it('should recognize namespace with wildcard scope', () => {
+            const lines = ['namespace * thrift.test'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'namespace', ['keyword.other.thrift']),
+                'namespace keyword should be keyword.other');
+            assert.ok(hasScopes(tokens, '*', ['keyword.other.namespace.thrift']),
+                'wildcard scope should be keyword.other.namespace');
+            assert.ok(tokens.some(t => t.text === 'thrift.test' && t.scopes.includes('entity.name.namespace.thrift')),
+                'namespace name should be entity.name.namespace');
+        });
+
+        it('should recognize namespace with simple language identifier', () => {
+            const lines = ['namespace java com.example.thrift'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'namespace', ['keyword.other.thrift']),
+                'namespace keyword should be keyword.other');
+            assert.ok(hasScopes(tokens, 'java', ['keyword.other.namespace.thrift']),
+                'language identifier should be keyword.other.namespace');
+            assert.ok(tokens.some(t => t.text === 'com.example.thrift' && t.scopes.includes('entity.name.namespace.thrift')),
+                'namespace name should be entity.name.namespace');
+        });
+
+        it('should handle namespace with annotation containing URL', () => {
+            const lines = ["namespace xsd test (uri = 'http://thrift.apache.org/ns/ThriftTest')"];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'namespace', ['keyword.other.thrift']),
+                'namespace keyword should be keyword.other');
+            assert.ok(hasScopes(tokens, 'xsd', ['keyword.other.namespace.thrift']),
+                'language identifier xsd should be keyword.other.namespace');
+            assert.ok(hasScopes(tokens, 'test', ['entity.name.namespace.thrift']),
+                'namespace name should be entity.name.namespace');
+            // The URL in annotation should NOT trigger comment scope
+            const urlCommentTokens = tokens.filter(t => t.scopes.includes('comment.line.double-slash'));
+            assert.strictEqual(urlCommentTokens.length, 0,
+                'URL // in annotation should not trigger comment scope');
+            // Annotation should be recognized
+            assert.ok(tokens.some(t => t.scopes.includes('meta.annotation.thrift')),
+                'namespace annotation should have meta.annotation scope');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

This PR addresses findings from a code review of the branch against `master`. Two commits are included:

### `fix(formatter)`: Eliminate module-level state and fix annotation depth tracking
- **P0 — `serviceAnnotationDepth` parameterized**: Replaced the shared module-level variable in `service-content.ts` with a caller-maintained `annotationDepth` parameter + return value. Prevents state leakage across formatter calls when exceptions occur mid-formatting. The service and interaction paths each maintain independent counters, reset to 0 on block close.
- **P1 — annotation `}` detection**: Switched from `line.startsWith('}')` to net-brace counting (`opens - closes`) per line, correctly handling nested `{}` literals (e.g. map literals) inside annotation bodies without premature depth reduction.
- **P1 — remove unused `interactionFunctionIndex`**: Was built in `buildAstIndex` but never consumed by any caller.
- **P1 — `node ;` whitespace cleanup**: Removed trailing space before semicolon in node alias assignments across 8 files (`ast/parser.ts`, `definition/lookup.ts`, `document-symbol-provider.ts`, `references/` subtree, `formatter/ast-index.ts`).
- **P1 — `vscode:prepublish` missing compile**: Added `pnpm run compile &&` before `pnpm run bundle` so the `out/` directory stays in sync when publishing.
- **P2 — `MEMORY_CHECK_INTERVAL`**: Corrected to `120000` ms — commit `f57abf6` declared the change in its message but never updated the code.
- **P2 — `?? undefined` cleanup**: Removed redundant nullish-coalescing-to-undefined in `selection-range-provider.ts`.

### `fix(deps)`: Remove deprecated `vscode` package and add pnpm overrides to resolve all known vulnerabilities

All 12 vulnerabilities reported by `pnpm audit` (1 critical, 6 high, 2 moderate, 3 low) are eliminated:

| Root cause | Fix | Vulnerabilities removed |
|---|---|---|
| `vscode@1.1.37` (deprecated) | Removed entirely — tests fully mock `vscode` via `require-hook.js`, the package is never loaded | critical `minimist`, 4× high `minimatch`, low `diff`, low `@tootallnate/once` |
| `mocha → glob <10.5.0` | `pnpm.overrides: "glob": ">=10.5.0"` | high command injection (GHSA-5j98-mcp5-4vw2) |
| `mocha → serialize-javascript <7.0.5` | `pnpm.overrides: "serialize-javascript": ">=7.0.5"` | high RCE + moderate CPU DoS (GHSA-qj8w-gfj5-8c6v) |
| `mocha → diff <8.0.3` | `pnpm.overrides: "diff": ">=8.0.3"` | low parsePatch DoS (GHSA-73rr-hh4g-fpgx) |

`pnpm audit` now reports **0 known vulnerabilities**.

## Test plan

- [x] `pnpm run lint` — passes with no warnings
- [x] `pnpm run build` — clean TypeScript compile + esbuild bundle
- [x] `pnpm test` — **451 tests passing**, 0 failing
- [x] `pnpm audit` — 0 known vulnerabilities

🤖 Generated with [Claude Code](https://claude.ai/claude-code)