### PR TITLE
test: strengthen positive-path assertions in hover and node-locator tests

### DIFF
--- a/tests/src/hover-provider/test-hover-provider-extended.js
+++ b/tests/src/hover-provider/test-hover-provider-extended.js
@@ -91,9 +91,8 @@ struct Foo {
         const doc = createMockDocument(typedefText);
         const pos = new Position(4, 9);
         const hover = await provider.provideHover(doc, pos, createCancellationToken());
-        if (hover) {
-            assert.ok(hover.contents, 'Should have hover contents');
-        }
+        assert.ok(hover, 'Expected hover result for typedef reference');
+        assert.ok(hover.contents, 'Should have hover contents');
     });
 
     it('should provide hover for const', async () => {
@@ -107,12 +106,11 @@ struct Config {
         const doc = createMockDocument(constText);
         const pos = new Position(4, 21);
         const hover = await provider.provideHover(doc, pos, createCancellationToken());
-        if (hover) {
-            assert.ok(hover.contents, 'Should have hover contents');
-        }
+        assert.ok(hover, 'Expected hover result for const reference');
+        assert.ok(hover.contents, 'Should have hover contents');
     });
 
-    it('should provide hover for service method', async () => {
+    it('should provide hover for service method return type', async () => {
         const provider = new ThriftHoverProvider();
         const svcText = `service UserService {
     /// Get user by ID
@@ -123,11 +121,11 @@ struct User {
     1: string name
 }`;
         const doc = createMockDocument(svcText);
-        const pos = new Position(1, 8);
+        // Position (2, 4) points to "User" return type on line 2, not the doc comment on line 1
+        const pos = new Position(2, 4);
         const hover = await provider.provideHover(doc, pos, createCancellationToken());
-        if (hover) {
-            assert.ok(hover.contents, 'Should have hover contents');
-        }
+        assert.ok(hover, 'Expected hover result for service method return type');
+        assert.ok(hover.contents, 'Should have hover contents');
     });
 
     it('should return undefined at whitespace-only position', async () => {
@@ -150,8 +148,7 @@ service API {
         const doc = createMockDocument(exceptionText);
         const pos = new Position(5, 30);
         const hover = await provider.provideHover(doc, pos, createCancellationToken());
-        if (hover) {
-            assert.ok(hover.contents, 'Should have hover contents');
-        }
+        assert.ok(hover, 'Expected hover result for exception type reference');
+        assert.ok(hover.contents, 'Should have hover contents');
     });
 });

--- a/tests/src/references/test-node-locator-advanced.js
+++ b/tests/src/references/test-node-locator-advanced.js
@@ -88,9 +88,8 @@ describe('node-locator advanced', () => {
         const ast = parseThrift('interaction MyInteraction {\n  void start()\n}');
         const pos = new vscode.Position(0, 5);
         const node = findNodeAtPosition(ast, pos);
-        if (node) {
-            assert.strictEqual(node.type, nodes.ThriftNodeType.Interaction);
-        }
+        assert.ok(node, 'Expected interaction node at position');
+        assert.strictEqual(node.type, nodes.ThriftNodeType.Interaction);
     });
 
     it('should find nested struct field deeply', () => {
@@ -106,8 +105,7 @@ describe('node-locator advanced', () => {
         const ast = parseThrift('const i32 MAX = 100');
         const pos = new vscode.Position(0, 6);
         const node = findNodeAtPosition(ast, pos);
-        if (node) {
-            assert.strictEqual(node.type, nodes.ThriftNodeType.Const);
-        }
+        assert.ok(node, 'Expected const node at position');
+        assert.strictEqual(node.type, nodes.ThriftNodeType.Const);
     });
 });


### PR DESCRIPTION
## Summary

- **hover provider**: Replace `if (hover) { assert.ok(...) }` guards with unconditional `assert.ok(hover, ...)` in all 4 positive-path tests so they fail when `provideHover` regresses to returning `undefined`. Also corrects the 'service method' test cursor from `(1, 8)` (inside a `///` doc comment, legitimately yields no hover) to `(2, 4)` on the `User` return type; test renamed to 'service method return type'.

- **node-locator**: Replace `if (node)` guards in the `interaction` and `const` positive-path tests with unconditional `assert.ok(node, ...)` so `findNodeAtPosition` regressions are caught by CI.

## Test plan

- [x] `pnpm run lint` — no errors
- [x] `pnpm run build` — clean build
- [x] `pnpm test` — 656 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)