### PR TITLE
fix(syntax): restore correct type scope for deeply nested container types

### DIFF
--- a/syntaxes/thrift.tmLanguage.json
+++ b/syntaxes/thrift.tmLanguage.json
@@ -212,14 +212,20 @@
           "end": ">",
           "patterns": [
             {
-              "include": "#types"
+              "include": "#nested-types"
             },
             {
-              "include": "#nested-types"
+              "include": "#types"
             },
             {
               "name": "entity.name.type.thrift",
               "match": "[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*"
+            },
+            {
+              "include": "#annotations"
+            },
+            {
+              "include": "#strings"
             },
             {
               "include": "#punctuation-comma"
@@ -239,14 +245,20 @@
           "end": ">",
           "patterns": [
             {
-              "include": "#types"
+              "include": "#nested-types"
             },
             {
-              "include": "#nested-types"
+              "include": "#types"
             },
             {
               "name": "entity.name.type.thrift",
               "match": "[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*"
+            },
+            {
+              "include": "#annotations"
+            },
+            {
+              "include": "#strings"
             },
             {
               "include": "#comments"
@@ -263,14 +275,20 @@
           "end": ">",
           "patterns": [
             {
-              "include": "#types"
+              "include": "#nested-types"
             },
             {
-              "include": "#nested-types"
+              "include": "#types"
             },
             {
               "name": "entity.name.type.thrift",
               "match": "[a-zA-Z0-9_]+\\.[A-Z][a-zA-Z0-9_]*"
+            },
+            {
+              "include": "#annotations"
+            },
+            {
+              "include": "#strings"
             },
             {
               "include": "#comments"
@@ -727,10 +745,10 @@
             "2": {
               "patterns": [
                 {
-                  "include": "#types"
+                  "include": "#nested-types"
                 },
                 {
-                  "include": "#nested-types"
+                  "include": "#types"
                 }
               ]
             },
@@ -778,20 +796,14 @@
           },
           "patterns": [
             {
-              "include": "#types"
+              "include": "#nested-types"
             },
             {
-              "include": "#nested-types"
+              "include": "#types"
             },
             {
               "name": "punctuation.separator.thrift",
               "match": ","
-            },
-            {
-              "include": "#types"
-            },
-            {
-              "include": "#nested-types"
             },
             {
               "include": "#comments"
@@ -851,20 +863,20 @@
             "3": {
               "patterns": [
                 {
-                  "include": "#types"
+                  "include": "#nested-types"
                 },
                 {
-                  "include": "#nested-types"
+                  "include": "#types"
                 }
               ]
             },
             "4": {
               "patterns": [
                 {
-                  "include": "#types"
+                  "include": "#nested-types"
                 },
                 {
-                  "include": "#nested-types"
+                  "include": "#types"
                 }
               ]
             },
@@ -953,10 +965,10 @@
           },
           "patterns": [
             {
-              "include": "#types"
+              "include": "#nested-types"
             },
             {
-              "include": "#nested-types"
+              "include": "#types"
             },
             {
               "include": "#punctuation-comma"

--- a/tests/src/test-grammar-tokenization.js
+++ b/tests/src/test-grammar-tokenization.js
@@ -386,6 +386,87 @@ describe('TextMate Grammar Tokenization', () => {
         });
     });
 
+    describe('Nested container type tokenization', () => {
+        it('i32 inside set<i32> in a struct field should have storage.type.thrift', () => {
+            const lines = ['struct S {', '  1: set<i32> field,', '}'];
+            const tokens = tokenizeLines(lines);
+            assert.ok(hasScopes(tokens, 'i32', ['storage.type.thrift']),
+                'i32 inside set<> should have storage.type.thrift');
+        });
+
+        it('inner container keyword in 2-level nesting should have storage.type.thrift', () => {
+            const lines = ['struct S {', '  1: list<map<string, i32>> field,', '}'];
+            const tokens = tokenizeLines(lines);
+            assert.ok(hasScopes(tokens, 'map', ['storage.type.thrift']),
+                'map keyword inside list<> should have storage.type.thrift');
+            assert.ok(hasScopes(tokens, 'i32', ['storage.type.thrift']),
+                'i32 inside map<> inside list<> should have storage.type.thrift');
+        });
+
+        it('all type keywords in 3-level nesting should have storage.type.thrift', () => {
+            const lines = ['struct S {', '  1: list<map<string, set<i32>>> field,', '}'];
+            const tokens = tokenizeLines(lines);
+            assert.ok(hasScopes(tokens, 'map', ['storage.type.thrift']),
+                'map inside list<> should have storage.type.thrift');
+            assert.ok(hasScopes(tokens, 'set', ['storage.type.thrift']),
+                'set inside map<> inside list<> should have storage.type.thrift');
+            assert.ok(hasScopes(tokens, 'i32', ['storage.type.thrift']),
+                'i32 inside set<> (3 levels) should have storage.type.thrift');
+        });
+
+        it('annotation after inner type in nested context should have meta.annotation.thrift', () => {
+            const lines = [
+                'struct S {',
+                '  1: map<set<i32> (python.immutable = ""), string> field,',
+                '}'
+            ];
+            const tokens = tokenizeLines(lines);
+            assert.ok(hasScopes(tokens, 'i32', ['storage.type.thrift']),
+                'i32 inside set<> in annotated nested map should have storage.type.thrift');
+            assert.ok(tokens.some(t => t.scopes.includes('meta.annotation.thrift')),
+                'annotation (python.immutable = "") inside nested type should have meta.annotation.thrift');
+        });
+
+        it('user-reported: deeply nested type with multiple annotations should tokenize inner types correctly', () => {
+            const lines = [
+                'struct Insanity {',
+                '  3: required list<map<set<i32> (python.immutable = ""), map<i32,set<list<map<Insanity,string>(python.immutable = "")> (python.immutable = "")>>>> list_field,',
+                '}'
+            ];
+            const tokens = tokenizeLines(lines);
+
+            const i32Tokens = tokens.filter(t => t.text === 'i32');
+            assert.ok(i32Tokens.length > 0, 'should find i32 tokens');
+            assert.ok(i32Tokens.every(t => t.scopes.includes('storage.type.thrift')),
+                'all i32 tokens in deeply nested type should have storage.type.thrift');
+
+            const setTokens = tokens.filter(t => t.text === 'set');
+            assert.ok(setTokens.every(t => t.scopes.includes('storage.type.thrift')),
+                'all set tokens in nested type should have storage.type.thrift');
+
+            assert.ok(tokens.some(t => t.scopes.includes('meta.annotation.thrift')),
+                'annotations inside nested types should have meta.annotation.thrift');
+        });
+
+        it('user-defined type inside deeply nested map should have entity.name.type.thrift', () => {
+            const lines = ['struct S {', '  1: map<string, list<MyType>> field,', '}'];
+            const tokens = tokenizeLines(lines);
+            assert.ok(hasScopes(tokens, 'MyType', ['entity.name.type.thrift']),
+                'user-defined type inside nested containers should have entity.name.type.thrift');
+        });
+
+        it('typedef with nested containers should tokenize inner types correctly', () => {
+            const lines = ['typedef set<map<string, list<i64>>> ComplexType'];
+            const tokens = tokenizeLines(lines);
+            assert.ok(hasScopes(tokens, 'map', ['storage.type.thrift']),
+                'map inside typedef nested set<> should have storage.type.thrift');
+            assert.ok(hasScopes(tokens, 'list', ['storage.type.thrift']),
+                'list inside typedef nested map<> should have storage.type.thrift');
+            assert.ok(hasScopes(tokens, 'i64', ['storage.type.thrift']),
+                'i64 inside typedef 3-level nesting should have storage.type.thrift');
+        });
+    });
+
     describe('Namespace definition tokenization', () => {
         it('should recognize namespace with scoped language identifier', () => {
             const lines = ['namespace cpp.noexist ThriftTest'];


### PR DESCRIPTION
## Summary

- **Root cause**: In `syntaxes/thrift.tmLanguage.json`, `#types` was listed before `#nested-types` inside every `map<>`, `list/set<>`, and `senum/slist/stream/sink<>` rule. TextMate picks the **first matching pattern** at each position, so container keywords (`map`, `set`, `list`) inside a nested context were consumed by `#types` (keyword-only, no `<`) before `#nested-types` could start a proper recursive context. The first stray `>` then closed the wrong outer context, causing all inner tokens (`i32`, `set`, user-defined types, etc.) to lose their `storage.type.thrift` scope.
- **Secondary issue**: Missing `#annotations` and `#strings` in nested-type patterns meant inline annotations like `(python.immutable = "")` after a contained type were not recognised.

## Changes

### `syntaxes/thrift.tmLanguage.json`
- Moved `#nested-types` **before** `#types` in all recursive nested-type rule patterns (`map<>`, `list/set<>`, `senum/slist/stream/sink<>`) so `map<` / `set<` enter their own contexts before being consumed as bare keywords.
- Added `#annotations` and `#strings` to those same pattern lists so inline annotations get `meta.annotation.thrift` scope.
- Applied the same `#nested-types`-first ordering to `typedef-definitions`, `const-definitions`, `method-definitions`, and `method-parameters` captures where the same ordering bug existed.

### `tests/src/test-grammar-tokenization.js`
Added a new **"Nested container type tokenization"** describe block with 7 test cases:

| Test | Verifies |
|------|---------|
| `set<i32>` 1-level | `i32` gets `storage.type.thrift` (regression baseline) |
| `list<map<…>>` 2-level | `map` keyword enters nested context |
| `list<map<…, set<i32>>>` 3-level | `set`/`i32` at 3 levels get type scope |
| Annotation in nested context | `(python.immutable = "")` gets `meta.annotation.thrift` |
| User-reported exact expression | All `i32`/`set` tokens in `list<map<set<i32>(ann),map<i32,set<list<map<…>>>>>` have type scope |
| User-defined type in nested map | `MyType` gets `entity.name.type.thrift` |
| typedef with nested containers | 3-level typedef types get correct scopes |

## Test plan

- [x] `pnpm run lint` — no errors
- [x] `pnpm run build` — clean build
- [x] All 663 tests pass (`pnpm test`)
- [x] New 7 nested-container tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)