### PR TITLE
fix(formatter): remove spurious extra space before comment on no-comma fields

### DIFF
--- a/src/formatter/struct-format.ts
+++ b/src/formatter/struct-format.ts
@@ -129,7 +129,7 @@ export function formatStructFields(
         // Trailing spaces in suffix are alignment padding and should be ignored
         let cleanSuffixForWidth = field.suffix || '';
         // Detect comma from suffix (original location)
-        let hasCommaForWidth = field.suffix ? /,\s*$/.test(field.suffix) : false;
+        const hasCommaForWidth = field.suffix ? /,\s*$/.test(field.suffix) : false;
 
         // Remove trailing spaces that are just for alignment
         // These spaces are not meaningful content and should not affect width calculation

--- a/src/formatter/struct-format.ts
+++ b/src/formatter/struct-format.ts
@@ -131,15 +131,6 @@ export function formatStructFields(
         // Detect comma from suffix (original location)
         let hasCommaForWidth = field.suffix ? /,\s*$/.test(field.suffix) : false;
 
-        // Idempotency fix: when preserving commas, if we have a comment/annotation
-        // and the field is likely not the last one, assume comma should be present
-        // This handles cases where comma was moved to end in previous format pass
-        if (options.trailingComma === 'preserve' && !hasCommaForWidth && (field.comment || (field.annotation !== undefined && field.annotation !== ''))) {
-            // Heuristic: fields with comments/annotations in a struct are usually not the last field
-            // This is imperfect but ensures idempotency for common cases
-            hasCommaForWidth = true;
-        }
-
         // Remove trailing spaces that are just for alignment
         // These spaces are not meaningful content and should not affect width calculation
         cleanSuffixForWidth = cleanSuffixForWidth.replace(/\s+$/, '');

--- a/tests/src/formatter/test-struct-formatting.js
+++ b/tests/src/formatter/test-struct-formatting.js
@@ -48,4 +48,27 @@ describe('struct-formatting', () => {
     it('should pass all test assertions', () => {
         testStructFormatting();
     });
+
+    it('no-trailing-comma field with comment gets 1 space before comment when it is the widest field', () => {
+        const assert = require('assert');
+        const formatter = new ThriftFormatter();
+        const input = [
+            'exception UserNotFoundException {',
+            '    1: required string message,',
+            '    2: optional i32    errorCode = 404  // error code',
+            '}'
+        ].join('\n');
+        const result = formatter.format(input, {
+            alignTypes: true,
+            alignFieldNames: true,
+            alignComments: true,
+            trailingComma: 'preserve',
+            indentSize: 4,
+            insertSpaces: true,
+            tabSize: 4
+        });
+        const lines = result.split('\n');
+        assert.ok(lines[2].includes('errorCode = 404 //'), `expected 1 space before comment, got: ${lines[2]}`);
+        assert.ok(!lines[2].includes('errorCode = 404  //'), `should NOT have 2 spaces before comment, got: ${lines[2]}`);
+    });
 });

--- a/tests/src/formatter/test-struct-formatting.js
+++ b/tests/src/formatter/test-struct-formatting.js
@@ -1,3 +1,4 @@
+const assert = require('assert');
 const {ThriftFormatter} = require('../../../out/formatter/index.js');
 
 function testStructFormatting() {
@@ -50,7 +51,6 @@ describe('struct-formatting', () => {
     });
 
     it('no-trailing-comma field with comment gets 1 space before comment when it is the widest field', () => {
-        const assert = require('assert');
         const formatter = new ThriftFormatter();
         const input = [
             'exception UserNotFoundException {',


### PR DESCRIPTION
## What changed

Removed a heuristic in `src/formatter/struct-format.ts` that was forcing `hasCommaForWidth = true` for any struct field that had a comment/annotation but no trailing comma.

## Why

The heuristic caused a 1-character mismatch between the `maxContentWidth` calculation loop and the render loop:

- **Width loop**: virtual `+1` added for a phantom comma → `maxContentWidth = X + 1`
- **Render loop**: no actual comma added → `currentWidth = X`
- **Result**: `diff = 1` → `basePad = 2` (2 spaces before comment instead of 1)

Example before fix:
```thrift
exception UserNotFoundException {
    1: required string message,         // 错误消息
    2: optional i32    errorCode = 404  // 错误代码  ← 2 spaces ✗
}
```

After fix:
```thrift
exception UserNotFoundException {
    1: required string message,        // 错误消息
    2: optional i32    errorCode = 404 // 错误代码  ← 1 space ✓
}
```

## Idempotency

The heuristic was labelled as an "idempotency fix" but was not actually necessary. Without it, `maxContentWidth` is determined solely by actual rendered widths (content + real comma when present). A second format pass produces identical output — verified by the existing `double-format-idempotency` test suite which continues to pass.

## Tests

- Existing `double-format-idempotency` suite: all passing ✓  
- New regression test added in `test-struct-formatting.js`: verifies no-comma widest field gets exactly 1 space before its comment ✓  
- Full suite: 664 passing ✓