### PR TITLE
fix(grammar): fix service method parameter scopes and enum member name tokenization

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "thrift-support",
   "displayName": "Thrift Support",
   "description": "Apache Thrift language support: syntax highlighting, formatting, diagnostics, navigation, completion, and rename",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "publisher": "tanzz",
   "icon": "icon.png",
   "repository": {

--- a/syntaxes/thrift.tmLanguage.json
+++ b/syntaxes/thrift.tmLanguage.json
@@ -614,7 +614,7 @@
             },
             {
               "name": "meta.enum.field.thrift",
-              "match": "\\s*([A-Z_][A-Z0-9_]*)(?:\\s*(=)\\s*(-?[0-9]+))?\\s*(,)?",
+              "match": "\\s*([A-Za-z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*(-?[0-9]+))?\\s*(,)?",
               "captures": {
                 "1": {
                   "name": "constant.other.enum.thrift"
@@ -948,10 +948,13 @@
       "patterns": [
         {
           "name": "meta.parameter.thrift",
-          "begin": "\\s*([0-9]+)\\s*:\\s*",
+          "begin": "\\s*([0-9]+)\\s*:\\s*(required|optional)?\\s*",
           "beginCaptures": {
             "1": {
               "name": "constant.numeric.thrift"
+            },
+            "2": {
+              "name": "storage.modifier.thrift"
             }
           },
           "end": "\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*(,)?",

--- a/syntaxes/thrift.tmLanguage.json
+++ b/syntaxes/thrift.tmLanguage.json
@@ -948,7 +948,7 @@
       "patterns": [
         {
           "name": "meta.parameter.thrift",
-          "begin": "\\s*([0-9]+)\\s*:\\s*(required|optional)?\\s*",
+          "begin": "\\s*([0-9]+)\\s*:\\s*(?:(required|optional)\\b\\s+)?",
           "beginCaptures": {
             "1": {
               "name": "constant.numeric.thrift"

--- a/test-files/example.thrift
+++ b/test-files/example.thrift
@@ -29,32 +29,32 @@ enum Status {
 struct User {
     1: required UserId id, // 用户唯一标识
 
-    2:  required string             name  (go.tag='json:"name"'),      // 用户姓名
-    3:  optional Email              email (go.tag="xx:\"len($)>0\""),  // 邮箱地址
-    4:  optional i32                age,                               // 年龄
-    5:  optional Status             status = Status.ACTIVE,            // 用户状态，默认为活跃
-    6:  optional list<string>       tags,                              // 用户标签列表
-    7:  optional map<string,string> metadata,                          // 用户元数据
-    8:  optional bool               isVerified = false,                // 是否已验证，默认未验证
-    9:  optional double             score = 0.0,                       // 用户评分，默认0.0
-    10: optional binary             avatar                             // 用户头像二进制数据
+    2:  required string             name       (go.tag='json:"name"'),     // 用户姓名
+    3:  optional Email              email      (go.tag="xx:\"len($)>0\""), // 邮箱地址
+    4:  optional i32                age,                                   // 年龄
+    5:  optional Status             status     = Status.ACTIVE,            // 用户状态，默认为活跃
+    6:  optional list<string>       tags,                                  // 用户标签列表
+    7:  optional map<string,string> metadata,                              // 用户元数据
+    8:  optional bool               isVerified = false,                    // 是否已验证，默认未验证
+    9:  optional double             score      = 0.0,                      // 用户评分，默认0.0
+    10: optional binary             avatar                                 // 用户头像二进制数据
 }
 
 /**
  * Test2 struct
  */
 struct Test2 {
-    1: required i32    f1,          # 123123
-    2: optional string F2URL = "",  #测试f2
-    3: optional i32    f3 = 0,      # ())
+    1: required i32    f1,         # 123123
+    2: optional string F2URL = "", #测试f2
+    3: optional i32    f3    = 0,  # ())
 }
 
 // Union definition - 搜索条件联合体
 union SearchCriteria {
-    1: string       name,   // 按姓名搜索
-    2: Email        email,  // 按邮箱搜索
-    3: UserId       id,     // 按用户ID搜索
-    4: list<string> tags    // 按标签列表搜索
+    1: string       name,  // 按姓名搜索
+    2: Email        email, // 按邮箱搜索
+    3: UserId       id,    // 按用户ID搜索
+    4: list<string> tags   // 按标签列表搜索
 }
 
 // Exception definition - 异常定义

--- a/tests/src/test-grammar-tokenization.js
+++ b/tests/src/test-grammar-tokenization.js
@@ -386,6 +386,94 @@ describe('TextMate Grammar Tokenization', () => {
         });
     });
 
+    describe('Method parameter required/optional modifier scoping', () => {
+        it('required modifier should have storage.modifier scope', () => {
+            const lines = ['service S {', '  void foo(1: required string name),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'required', ['storage.modifier.thrift']),
+                'required keyword in method parameter should have storage.modifier.thrift scope');
+        });
+
+        it('optional modifier should have storage.modifier scope', () => {
+            const lines = ['service S {', '  void foo(1: optional string name),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'optional', ['storage.modifier.thrift']),
+                'optional keyword in method parameter should have storage.modifier.thrift scope');
+        });
+
+        it('primitive type after required modifier should have storage.type scope, not variable.parameter', () => {
+            const lines = ['service S {', '  void foo(1: required string name),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'string', ['storage.type.thrift']),
+                'string type after required should have storage.type.thrift scope');
+            assert.ok(!getScopes(tokens, 'string').includes('variable.parameter.thrift'),
+                'string type should not be misidentified as variable.parameter.thrift');
+        });
+
+        it('parameter name after required + type should have variable.parameter scope', () => {
+            const lines = ['service S {', '  void foo(1: required string traceInfo),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(hasScopes(tokens, 'traceInfo', ['variable.parameter.thrift']),
+                'parameter name after required modifier should have variable.parameter.thrift scope');
+        });
+
+        it('trailing comma after parameter name should have punctuation.separator.comma scope', () => {
+            const lines = ['service S {', '  void foo(1: required string name,', '  2: required i32 id),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(tokens.some(t => t.text === ',' && t.scopes.includes('punctuation.separator.comma.thrift')),
+                'trailing comma after parameter name should have punctuation.separator.comma.thrift scope');
+        });
+
+        it('multi-parameter method with required should have correct scopes throughout', () => {
+            const lines = [
+                'service S {',
+                '  void foo(',
+                '    1: required string traceInfo,',
+                '    2: required PingRequest request',
+                '  ),',
+                '}'
+            ];
+            const tokens = tokenizeLines(lines);
+
+            const requiredTokens = tokens.filter(t => t.text === 'required');
+            assert.ok(requiredTokens.length >= 2, 'should find at least two required tokens');
+            assert.ok(requiredTokens.every(t => t.scopes.includes('storage.modifier.thrift')),
+                'all required keywords should have storage.modifier.thrift scope');
+            assert.ok(hasScopes(tokens, 'traceInfo', ['variable.parameter.thrift']),
+                'first parameter name should have variable.parameter.thrift scope');
+            assert.ok(hasScopes(tokens, 'request', ['variable.parameter.thrift']),
+                'second parameter name should have variable.parameter.thrift scope');
+        });
+
+        it('type name starting with "optional" should not have its prefix consumed as a modifier', () => {
+            // Word boundary regression: old regex (required|optional)?\s* greedily matched
+            // "optional" in "optionalData", splitting the type name and misassigning scopes.
+            const lines = ['service S {', '  void foo(1: optionalData name),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(!tokens.some(t => t.text === 'optional' && t.scopes.includes('storage.modifier.thrift')),
+                '"optional" prefix in type name optionalData should not tokenize as storage.modifier.thrift');
+            assert.ok(hasScopes(tokens, 'name', ['variable.parameter.thrift']),
+                'parameter name after optionalData type should still have variable.parameter.thrift scope');
+        });
+
+        it('type name starting with "required" should not have its prefix consumed as a modifier', () => {
+            // Word boundary regression: old regex greedily matched "required" in "requiredField".
+            const lines = ['service S {', '  void foo(1: requiredField name),', '}'];
+            const tokens = tokenizeLines(lines);
+
+            assert.ok(!tokens.some(t => t.text === 'required' && t.scopes.includes('storage.modifier.thrift')),
+                '"required" prefix in type name requiredField should not tokenize as storage.modifier.thrift');
+            assert.ok(hasScopes(tokens, 'name', ['variable.parameter.thrift']),
+                'parameter name after requiredField type should still have variable.parameter.thrift scope');
+        });
+    });
+
     describe('Nested container type tokenization', () => {
         it('i32 inside set<i32> in a struct field should have storage.type.thrift', () => {
             const lines = ['struct S {', '  1: set<i32> field,', '}'];


### PR DESCRIPTION
## Summary

- **method-parameters**: `begin` pattern was missing `(required|optional)?` capture group, causing `required`/`optional` to have no scope, the type name to be misidentified as `variable.parameter.thrift`, and the actual parameter name + trailing comma to fall outside `meta.parameter.thrift`
- **enum fields**: broadened the member-name regex from `[A-Z_][A-Z0-9_]*` to `[A-Za-z_][a-zA-Z0-9_]*` so PascalCase names (e.g. `Init`) tokenize as a single `constant.other.enum.thrift` instead of being split

## Test plan

- [x] Open a `.thrift` file with service method parameters using `required`/`optional` modifiers
- [x] Use **Developer: Inspect Editor Tokens and Scopes** to verify:
  - `required` / `optional` → `storage.modifier.thrift`
  - type (e.g. `string`, `PingRequest`) → `storage.type.thrift` / `entity.name.type.thrift`
  - parameter name → `variable.parameter.thrift`
  - trailing `,` → `punctuation.separator.comma.thrift`
- [x] Verify PascalCase enum members (e.g. `Init`) tokenize as a single `constant.other.enum.thrift`
- [x] Verify parameters without `required`/`optional` still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)