### PR TITLE
fix(security): guard against prototype pollution in merge utilities

### DIFF
--- a/tests/mock_vscode.js
+++ b/tests/mock_vscode.js
@@ -67,6 +67,7 @@ function mergeDeep(target, source) {
     }
     const output = {...target};
     Object.keys(source).forEach((key) => {
+        if (key === '__proto__' || key === 'constructor') return;
         const value = source[key];
         if (value && typeof value === 'object' && !Array.isArray(value)) {
             output[key] = mergeDeep(target[key] || {}, value);
@@ -176,6 +177,7 @@ const commonDefaults = {
 function mergeInPlace(target, source) {
     if (!source || typeof source !== 'object') return target;
     Object.keys(source).forEach((key) => {
+        if (key === '__proto__' || key === 'constructor') return;
         const value = source[key];
         if (
             value &&


### PR DESCRIPTION
## Summary

- 修复 `tests/mock_vscode.js` 中 `mergeDeep` 和 `mergeInPlace` 两个递归对象合并函数的原型污染漏洞
- 在 `forEach` 回调开头添加对 `__proto__` 和 `constructor` 键名的拦截，防止恶意输入污染 `Object.prototype`
- 解决 GitHub CodeQL 代码扫描告警 [#3](https://github.com/tzzs/vsce-thrift-support/security/code-scanning/3)（`js/prototype-pollution-utility`，中危，CWE-915）

## Test plan

- [x] `pnpm run build` 编译通过
- [x] `pnpm test` 全部 672 个测试通过
- [ ] 合并后 CodeQL 扫描应自动关闭告警 #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)