### PR TITLE
fix(formatter): correctly indent multi-line struct field default values

### DIFF
--- a/packages/core/src/ast/parser.ts
+++ b/packages/core/src/ast/parser.ts
@@ -421,13 +421,173 @@ export class ThriftParser {
     }
 
     private parseStructBody(parent: nodes.Struct): number {
-        return this.parseBracedBlock((line, scan) => {
+        // Phase 1: locate the opening brace; account for `{...}` closing on the same line
+        let braceCount = 0;
+        while (this.currentLine < this.lines.length) {
+            const line = this.lines[this.currentLine];
+            const scan = this.scanLine(line);
+            const braces = this.countBraces(scan.tokens);
+            if (braces.open > 0) {
+                braceCount = braces.open - braces.close;
+                break;
+            }
+            this.currentLine++;
+        }
+        this.currentLine++;
+        if (braceCount <= 0) {
+            return this.currentLine;
+        }
+
+        // Phase 2: parse fields with multi-line awareness, until struct body closes
+        while (this.currentLine < this.lines.length) {
+            const line = this.lines[this.currentLine];
+            const scan = this.scanLine(line);
+            const trimmed = scan.stripped.trim();
+
+            // Struct body terminator is a top-level `}` on this line
+            if (trimmed.startsWith('}')) {
+                this.currentLine++;
+                break;
+            }
+
+            if (!trimmed || scan.tokens.length === 0) {
+                this.currentLine++;
+                continue;
+            }
+
+            const startLine = this.currentLine;
             const field = this.parseStructFieldLine(parent, line, scan.stripped, scan.tokens);
             if (field) {
+                const endLine = this.computeStructFieldEndLine(startLine);
+                if (endLine > startLine) {
+                    field.range = this.createRange(
+                        startLine,
+                        0,
+                        endLine,
+                        (this.lines[endLine] ?? '').length
+                    );
+                }
                 parent.fields.push(field);
                 this.addChild(parent, field);
+                this.currentLine = endLine + 1;
+            } else {
+                this.currentLine++;
             }
-        });
+        }
+        return this.currentLine;
+    }
+
+    /**
+     * 给定字段起始行，计算其真实结束行（考虑跨行 default value 与尾部注解）。
+     * 字符级扫描 `[]`/`{}`/`()` 嵌套；遇到 struct body 自身的 `}`（所有 brace 深度归零时出现的 `}`）则停止。
+     * 内联处理字符串字面量与单行/块注释，避免依赖 tokenizer 的跨行 state。
+     */
+    private computeStructFieldEndLine(startLine: number): number {
+        let depthAngle = 0;
+        let depthBracket = 0;
+        let depthBrace = 0;
+        let depthParen = 0;
+        let inBlockComment = false;
+
+        for (let li = startLine; li < this.lines.length; li++) {
+            const stripped = this.stripCommentsAndStrings(this.lines[li], inBlockComment);
+            inBlockComment = stripped.endsInBlockComment;
+            const text = stripped.text;
+            for (let i = 0; i < text.length; i++) {
+                const ch = text[i];
+                if (ch === '<') { depthAngle++; continue; }
+                if (ch === '>') { depthAngle = Math.max(0, depthAngle - 1); continue; }
+                if (ch === '[') { depthBracket++; continue; }
+                if (ch === ']') { depthBracket = Math.max(0, depthBracket - 1); continue; }
+                if (ch === '{') { depthBrace++; continue; }
+                if (ch === '}') {
+                    if (depthBrace === 0) {
+                        return Math.max(startLine, li - 1);
+                    }
+                    depthBrace--;
+                    continue;
+                }
+                if (ch === '(') { depthParen++; continue; }
+                if (ch === ')') { depthParen = Math.max(0, depthParen - 1); continue; }
+                if (depthAngle === 0 && depthBracket === 0 && depthBrace === 0 && depthParen === 0
+                    && (ch === ',' || ch === ';')) {
+                    return li;
+                }
+            }
+            if (!inBlockComment) {
+                const next = this.findNextNonEmptyLineRaw(li + 1);
+                if (next === -1) { return li; }
+                const nextStripped = this.stripCommentsAndStrings(this.lines[next], false).text.trim();
+                // Recovery: if the next line opens a new field, treat the current field as ended
+                // here even when brackets are still unbalanced (malformed source).
+                if (/^\d+\s*:/.test(nextStripped)) {
+                    return li;
+                }
+                if (depthAngle === 0 && depthBracket === 0 && depthBrace === 0 && depthParen === 0
+                    && nextStripped.startsWith('}')) {
+                    return li;
+                }
+            }
+        }
+        return this.lines.length - 1;
+    }
+
+    private findNextNonEmptyLineRaw(startIdx: number): number {
+        for (let i = startIdx; i < this.lines.length; i++) {
+            if (this.stripCommentsAndStrings(this.lines[i], false).text.trim()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * 去除字符串字面量内容与注释，仅保留结构性字符（括号、逗号、分号等）。
+     * 字符串内容替换为空格以保持列对齐稳定。
+     * 不修改 this.tokenizer 的跨行 state。
+     */
+    private stripCommentsAndStrings(line: string, inBlockComment: boolean): {text: string; endsInBlockComment: boolean} {
+        let out = '';
+        let i = 0;
+        let block = inBlockComment;
+        let escaped = false;
+        while (i < line.length) {
+            if (block) {
+                const close = line.indexOf('*/', i);
+                if (close === -1) {
+                    return {text: out, endsInBlockComment: true};
+                }
+                i = close + 2;
+                block = false;
+                continue;
+            }
+            const ch = line[i];
+            const next = i + 1 < line.length ? line[i + 1] : '';
+            if (ch === '/' && next === '*') {
+                block = true;
+                i += 2;
+                continue;
+            }
+            if ((ch === '/' && next === '/') || ch === '#') {
+                break;
+            }
+            if (ch === '"' || ch === '\'') {
+                const quote = ch;
+                i++;
+                escaped = false;
+                while (i < line.length) {
+                    const c = line[i];
+                    if (escaped) { escaped = false; i++; continue; }
+                    if (c === '\\') { escaped = true; i++; continue; }
+                    if (c === quote) { i++; break; }
+                    i++;
+                }
+                continue;
+            }
+            out += ch;
+            i++;
+        }
+        return {text: out, endsInBlockComment: block};
     }
 
     private parseStructFieldLine(parent: nodes.Struct, line: string, cleanLine: string, tokens: Token[]): nodes.Field | null {

--- a/packages/core/src/formatter/ast-index.ts
+++ b/packages/core/src/formatter/ast-index.ts
@@ -3,6 +3,8 @@ import * as nodes from '../ast/nodes.types';
 export interface AstIndex {
     structStarts: Map<number, nodes.Struct>;
     structFieldIndex: Map<number, nodes.Field>;
+    /** start.line → end.line for multi-line struct fields (only when end > start) */
+    structFieldEnds: Map<number, number>;
     enumStarts: Map<number, nodes.Enum>;
     enumMemberIndex: Map<number, nodes.EnumMember>;
     serviceStarts: Map<number, nodes.Service>;
@@ -20,6 +22,7 @@ export interface AstIndex {
 export function buildAstIndex(ast: nodes.ThriftDocument): AstIndex {
     const structStarts = new Map<number, nodes.Struct>();
     const structFieldIndex = new Map<number, nodes.Field>();
+    const structFieldEnds = new Map<number, number>();
     const enumStarts = new Map<number, nodes.Enum>();
     const enumMemberIndex = new Map<number, nodes.EnumMember>();
     const serviceStarts = new Map<number, nodes.Service>();
@@ -36,7 +39,17 @@ export function buildAstIndex(ast: nodes.ThriftDocument): AstIndex {
                 const structNode = node;
                 structStarts.set(structNode.range.start.line, structNode);
                 structNode.fields.forEach(field => {
-                    structFieldIndex.set(field.range.start.line, field);
+                    const startLine = field.range.start.line;
+                    const endLine = field.range.end.line;
+                    structFieldIndex.set(startLine, field);
+                    if (endLine > startLine) {
+                        structFieldEnds.set(startLine, endLine);
+                        for (let li = startLine + 1; li <= endLine; li++) {
+                            if (!structFieldIndex.has(li)) {
+                                structFieldIndex.set(li, field);
+                            }
+                        }
+                    }
                 });
                 break;
             }
@@ -77,6 +90,7 @@ export function buildAstIndex(ast: nodes.ThriftDocument): AstIndex {
     return {
         structStarts,
         structFieldIndex,
+        structFieldEnds,
         enumStarts,
         enumMemberIndex,
         serviceStarts,

--- a/packages/core/src/formatter/field-parser.ts
+++ b/packages/core/src/formatter/field-parser.ts
@@ -113,11 +113,14 @@ export function normalizeType(type: string): string {
 
 /**
  * 基于 AST 构建结构体字段描述。
- * @param line 原始行文本
+ * @param line 原始行文本（多行字段时为整段拼接、用 \n 分隔）
  * @param field AST 字段节点
  * @returns 结构体字段信息
  */
 export function buildStructFieldFromAst(line: string, field: nodes.Field): StructField | null {
+    if (line.includes('\n')) {
+        return buildMultiLineStructFieldFromAst(line, field);
+    }
     const {code, comment} = splitLineComment(line);
     let remainder = code.trim();
     let trailing = '';
@@ -158,6 +161,102 @@ export function buildStructFieldFromAst(line: string, field: nodes.Field): Struc
         comment,
         annotation
     };
+}
+
+/**
+ * 处理跨行的 struct field。
+ * 输入是源文件中 field 起始行到结束行的拼接（用 \n 分隔）。
+ * 输出的 suffix 中保留 \n，延续行已 trim 前导空白，留待格式化阶段重新缩进。
+ */
+function buildMultiLineStructFieldFromAst(text: string, field: nodes.Field): StructField | null {
+    const rawLines = text.split('\n');
+    const cleanedLines = rawLines.map(l => splitLineComment(l).code);
+    const qualifier = field.requiredness ?? '';
+    const type = normalizeType(field.fieldType || '');
+    const name = field.name ?? '';
+    if (!name || !type) {
+        return null;
+    }
+
+    const firstLine = cleanedLines[0];
+    const eqIdx = findTopLevelEqualsIndex(firstLine);
+    if (eqIdx === -1) {
+        // No `=` on the first line — fall back to single-line behavior on first line.
+        return buildStructFieldFromAst(rawLines[0], field);
+    }
+
+    const lastIdx = cleanedLines.length - 1;
+    let lastClean = cleanedLines[lastIdx].trimEnd();
+    let trailing = '';
+    const tsMatch = lastClean.match(/([,;]\s*)$/);
+    if (tsMatch) {
+        trailing = tsMatch[1].trim();
+        lastClean = lastClean.slice(0, lastClean.length - tsMatch[1].length).trimEnd();
+    }
+    let annotation = '';
+    const annSplit = splitTrailingAnnotation(lastClean);
+    if (annSplit.annotation) {
+        annotation = annSplit.annotation;
+        lastClean = annSplit.base.trimEnd();
+    }
+
+    const firstDV = firstLine.slice(eqIdx + 1).trim();
+    const dvParts: string[] = [firstDV];
+    for (let i = 1; i < lastIdx; i++) {
+        dvParts.push(cleanedLines[i].trim());
+    }
+    if (lastIdx > 0) {
+        const lastDV = lastClean.trim();
+        if (lastDV) {
+            dvParts.push(lastDV);
+        }
+    }
+    const defaultValueText = dvParts.join('\n');
+
+    let suffix = ` = ${defaultValueText}`;
+    if (trailing) {
+        suffix += trailing;
+    }
+
+    return {
+        line: text.trim(),
+        id: String(field.id),
+        qualifier,
+        type,
+        name,
+        suffix,
+        comment: '',
+        annotation
+    };
+}
+
+/**
+ * 找到首行中的顶层 `=`（不在字符串、`<>`、`[]`、`{}`、`()` 内）。
+ */
+function findTopLevelEqualsIndex(text: string): number {
+    const qt = new QuoteTracker();
+    let depthAngle = 0;
+    let depthBracket = 0;
+    let depthBrace = 0;
+    let depthParen = 0;
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (!qt.inside()) {
+            if (ch === '<') { depthAngle++; }
+            else if (ch === '>') { depthAngle = Math.max(0, depthAngle - 1); }
+            else if (ch === '[') { depthBracket++; }
+            else if (ch === ']') { depthBracket = Math.max(0, depthBracket - 1); }
+            else if (ch === '{') { depthBrace++; }
+            else if (ch === '}') { depthBrace = Math.max(0, depthBrace - 1); }
+            else if (ch === '(') { depthParen++; }
+            else if (ch === ')') { depthParen = Math.max(0, depthParen - 1); }
+            else if (ch === '=' && depthAngle === 0 && depthBracket === 0 && depthBrace === 0 && depthParen === 0) {
+                return i;
+            }
+        }
+        qt.feed(ch);
+    }
+    return -1;
 }
 
 /**

--- a/packages/core/src/formatter/formatter-core.ts
+++ b/packages/core/src/formatter/formatter-core.ts
@@ -95,6 +95,7 @@ export function formatThriftContent(
     const {
         structStarts,
         structFieldIndex,
+        structFieldEnds,
         enumStarts,
         enumMemberIndex,
         serviceStarts,
@@ -345,7 +346,9 @@ export function formatThriftContent(
                     buildStructFieldFromAst,
                     parseStructFieldText,
                     normalizeGenericsInSignature,
-                    isServiceMethod: (line, li) => isServiceMethodLine(line, li, serviceFunctionIndex)
+                    isServiceMethod: (line, li) => isServiceMethodLine(line, li, serviceFunctionIndex),
+                    sourceLines: lines,
+                    structFieldEnds
                 }
             );
             structFields = structResult.structFields;
@@ -355,6 +358,9 @@ export function formatThriftContent(
             indentLevel = structResult.indentLevel;
             inStruct = structResult.inStruct;
             if (structResult.handled) {
+                if (structResult.skipToIndex !== undefined && structResult.skipToIndex > i) {
+                    i = structResult.skipToIndex;
+                }
                 continue;
             }
         }

--- a/packages/core/src/formatter/struct-content.ts
+++ b/packages/core/src/formatter/struct-content.ts
@@ -15,6 +15,10 @@ interface StructContentDeps {
     parseStructFieldText: StructFieldParser;
     normalizeGenericsInSignature: SignatureNormalizer;
     isServiceMethod: ServiceMethodMatcher;
+    /** Original source lines (used for multi-line field slicing). */
+    sourceLines?: string[];
+    /** Map of multi-line field start line → end line (inclusive). */
+    structFieldEnds?: Map<number, number>;
 }
 
 interface StructContentResult {
@@ -23,6 +27,8 @@ interface StructContentResult {
     indentLevel: number;
     structFields: StructField[];
     formattedLines: string[];
+    /** When set, outer loop should skip to this line index (inclusive last consumed). */
+    skipToIndex?: number;
 }
 
 /**
@@ -75,16 +81,40 @@ export function formatStructContentLine(
     }
 
     const fieldNode = structFieldIndex.get(lineIndex);
-    const fieldInfo = fieldNode
-        ? deps.buildStructFieldFromAst(line, fieldNode)
-        : deps.parseStructFieldText(line);
+    // Continuation line of a multi-line field already consumed — swallow without output.
+    if (fieldNode && fieldNode.range.start.line !== lineIndex) {
+        return {
+            handled: true,
+            inStruct: true,
+            indentLevel,
+            structFields,
+            formattedLines: []
+        };
+    }
+    // For multi-line field start, build the field from the full source span so the
+    // formatter can re-indent continuation lines correctly.
+    let fieldInfo: StructField | null = null;
+    let skipToIndex: number | undefined;
+    if (fieldNode) {
+        const endLine = deps.structFieldEnds?.get(lineIndex);
+        if (endLine !== undefined && deps.sourceLines && endLine > lineIndex) {
+            const slice = deps.sourceLines.slice(lineIndex, endLine + 1).join('\n');
+            fieldInfo = deps.buildStructFieldFromAst(slice, fieldNode);
+            skipToIndex = endLine;
+        } else {
+            fieldInfo = deps.buildStructFieldFromAst(line, fieldNode);
+        }
+    } else {
+        fieldInfo = deps.parseStructFieldText(line);
+    }
     if (fieldInfo) {
         return {
             handled: true,
             inStruct: true,
             indentLevel,
             structFields: [...structFields, fieldInfo],
-            formattedLines: []
+            formattedLines: [],
+            skipToIndex
         };
     }
 

--- a/packages/core/src/formatter/struct-format.ts
+++ b/packages/core/src/formatter/struct-format.ts
@@ -95,13 +95,18 @@ export function formatStructFields(
         maxQualifierWidth = Math.max(maxQualifierWidth, field.qualifier.length);
         maxTypeWidth = Math.max(maxTypeWidth, field.type.length);
         maxNameWidth = Math.max(maxNameWidth, field.name.length);
-        if (options.alignAnnotations && field.annotation !== undefined && field.annotation !== '') {
+        const isMultiLineField = !!(field.suffix && field.suffix.includes('\n'));
+        if (!isMultiLineField && options.alignAnnotations && field.annotation !== undefined && field.annotation !== '') {
             maxAnnotationWidth = Math.max(maxAnnotationWidth, field.annotation.length);
         }
         return field;
     });
 
     parsedFields.forEach(field => {
+        // Multi-line fields' annotations/comments live on the last line and don't participate in alignment.
+        if (field.suffix && field.suffix.includes('\n')) {
+            return;
+        }
         let contentWidth = 0;
         contentWidth += maxFieldIdWidth + 2;
 
@@ -181,6 +186,9 @@ export function formatStructFields(
             if (f === undefined || f.annotation === undefined || f.annotation === '') {
                 return;
             }
+            if (f.suffix && f.suffix.includes('\n')) {
+                return;
+            }
             const w = calculateAnnotationStartPosition(
                 f,
                 options,
@@ -199,6 +207,18 @@ export function formatStructFields(
     const commentCount = parsedFields.reduce((acc, f) => acc + ((f !== undefined && f.comment) ? 1 : 0), 0);
 
     return parsedFields.map(field => {
+        if (field.suffix && field.suffix.includes('\n')) {
+            return formatMultiLineStructField(
+                field,
+                options,
+                indentLevel,
+                deps,
+                maxFieldIdWidth,
+                maxQualifierWidth,
+                maxTypeWidth,
+                maxNameWidth
+            );
+        }
         let formattedLine = deps.getIndent(indentLevel, options);
 
         const fieldIdWithColon = field.id + ':';
@@ -296,4 +316,121 @@ export function formatStructFields(
 
         return formattedLine;
     });
+}
+
+/**
+ * Format a struct field whose default value spans multiple lines.
+ * Outputs a multi-line string: header on the first line, continuation lines re-indented
+ * one level deeper, and the closing bracket + annotation/trailing on the final line.
+ */
+function formatMultiLineStructField(
+    field: StructField,
+    options: ThriftFormattingOptions,
+    indentLevel: number,
+    deps: StructFormatDeps,
+    maxFieldIdWidth: number,
+    maxQualifierWidth: number,
+    maxTypeWidth: number,
+    maxNameWidth: number
+): string {
+    const baseIndent = deps.getIndent(indentLevel, options);
+    const innerIndent = deps.getIndent(indentLevel + 1, options);
+
+    let suffix = field.suffix || '';
+    let hasComma = /,\s*$/.test(suffix);
+    const hasSemicolon = /;\s*$/.test(suffix);
+    suffix = suffix.replace(/\s+$/, '');
+    if (hasComma) {
+        suffix = suffix.replace(/,\s*$/, '');
+    }
+    if (hasSemicolon) {
+        suffix = suffix.replace(/;\s*$/, '');
+    }
+    if (options.trailingComma === 'add' && !hasComma && !hasSemicolon) {
+        hasComma = true;
+    } else if (options.trailingComma === 'remove' && hasComma && !hasSemicolon) {
+        hasComma = false;
+    }
+
+    // suffix is like " = {\nLine2\nLine3\n}"  — strip leading " = "
+    const eqStripped = suffix.replace(/^\s*=\s*/, '');
+    const parts = eqStripped.split('\n');
+    const firstDV = parts[0] ?? '';
+    const middleDV = parts.length > 2 ? parts.slice(1, -1) : [];
+    const lastDV = parts.length > 1 ? parts[parts.length - 1] : '';
+
+    // String continuation (backslash-terminated multi-line string): preserve verbatim
+    // so the embedded whitespace inside the string isn't perturbed.
+    if (firstDV.startsWith('"') || firstDV.startsWith('\'')) {
+        let header = baseIndent;
+        header += (field.id + ':').padEnd(maxFieldIdWidth + 1) + ' ';
+        if (options.alignTypes) {
+            header += field.qualifier.padEnd(maxQualifierWidth);
+            if (maxQualifierWidth > 0) {
+                header += ' ';
+            }
+            header += field.type.padEnd(maxTypeWidth);
+        } else {
+            header += field.qualifier;
+            if (field.qualifier.length > 0) {
+                header += ' ';
+            }
+            header += field.type;
+        }
+        header += ' ';
+        header += options.alignFieldNames ? field.name.padEnd(maxNameWidth) : field.name;
+        header += ' = ' + firstDV;
+        const tailLines = [...middleDV];
+        let last = lastDV;
+        if (field.annotation !== undefined && field.annotation !== '') {
+            last += ' ' + field.annotation;
+        }
+        if (hasSemicolon) { last += ';'; }
+        else if (hasComma) { last += ','; }
+        if (field.comment) { last += ' ' + field.comment; }
+        if (parts.length > 1) {
+            tailLines.push(last);
+        }
+        return [header, ...tailLines].join('\n');
+    }
+
+    let firstLine = baseIndent;
+    firstLine += (field.id + ':').padEnd(maxFieldIdWidth + 1) + ' ';
+    if (options.alignTypes) {
+        firstLine += field.qualifier.padEnd(maxQualifierWidth);
+        if (maxQualifierWidth > 0) {
+            firstLine += ' ';
+        }
+        firstLine += field.type.padEnd(maxTypeWidth);
+    } else {
+        firstLine += field.qualifier;
+        if (field.qualifier.length > 0) {
+            firstLine += ' ';
+        }
+        firstLine += field.type;
+    }
+    firstLine += ' ';
+    if (options.alignFieldNames) {
+        firstLine += field.name.padEnd(maxNameWidth);
+    } else {
+        firstLine += field.name;
+    }
+    firstLine += ' = ' + firstDV;
+
+    const middleLines = middleDV.map(m => innerIndent + m);
+
+    let lastLine = baseIndent + lastDV;
+    if (field.annotation !== undefined && field.annotation !== '') {
+        lastLine += ' ' + field.annotation;
+    }
+    if (hasSemicolon) {
+        lastLine += ';';
+    } else if (hasComma) {
+        lastLine += ',';
+    }
+    if (field.comment) {
+        lastLine += ' ' + field.comment;
+    }
+
+    return [firstLine, ...middleLines, lastLine].join('\n');
 }

--- a/tests/fixtures/golden/annotation-edge-cases.formatted.thrift
+++ b/tests/fixtures/golden/annotation-edge-cases.formatted.thrift
@@ -13,30 +13,30 @@ struct SingleElementCollections {
 
 // Test nested collections with annotations
 struct NestedCollections {
-    1: list<list<string>>    nestedList = [["a", "b"], ["c", "d"]] (description="Nested list"),
-    2: map<string,list<i32>> complexMap = {
-    "group1": [1, 2, 3],
-    "group2": [4, 5, 6]
-} (description="Complex nested structure"),
-3: list<map<string,set<i32>>> deepNested = [
-{"set1": [1, 2], "set2": [3, 4]},
-{"set3": [5, 6], "set4": [7, 8]}
-] (description="Deep nested structure")
+    1: list<list<string>>         nestedList = [["a", "b"], ["c", "d"]] (description="Nested list"),
+    2: map<string,list<i32>>      complexMap = {
+        "group1": [1, 2, 3],
+        "group2": [4, 5, 6]
+    } (description="Complex nested structure"),
+    3: list<map<string,set<i32>>> deepNested = [
+        {"set1": [1, 2], "set2": [3, 4]},
+        {"set3": [5, 6], "set4": [7, 8]}
+    ] (description="Deep nested structure")
 }
 
 // Test multi-line default values with annotations
 struct MultiLineDefaults {
-    1: list<string> multiList = [
-    "line1",
-    "line2",
-    "line3"
+    1: list<string>       multiList   = [
+        "line1",
+        "line2",
+        "line3"
     ] (description="Multi-line list"),
-    2: map<string,string> multiMap = {
-    "key1": "value1",
-    "key2": "value2",
-    "key3": "value3"
-} (description="Multi-line map"),
-3: string multiString = "This is a very long string that spans \
+    2: map<string,string> multiMap    = {
+        "key1": "value1",
+        "key2": "value2",
+        "key3": "value3"
+    } (description="Multi-line map"),
+    3: string             multiString = "This is a very long string that spans \
 multiple lines and should preserve annotation \
 alignment properly" (description="Multi-line string")
 }
@@ -69,15 +69,15 @@ struct MixedAlignment {
 
 // Test edge cases with trailing commas and different collection styles
 struct CollectionStyles {
-    1: list<i32> inlineList    = [1, 2, 3] (style="inline"),
-    2: list<i32> multilineList = [
-    1,
-    2,
-    3
+    1: list<i32>       inlineList    = [1, 2, 3]      (style="inline"),
+    2: list<i32>       multilineList = [
+        1,
+        2,
+        3
     ] (style="multiline"),
-    3: map<string,i32> inlineMap    = {"a":1, "b":2} (style="inline"),
-    4: map<string,i32> multilineMap = {
-    "a": 1,
-    "b": 2
-} (style="multiline")
+    3: map<string,i32> inlineMap     = {"a":1, "b":2} (style="inline"),
+    4: map<string,i32> multilineMap  = {
+        "a": 1,
+        "b": 2
+    } (style="multiline")
 }


### PR DESCRIPTION
## Summary

- Fix a long-standing formatter regression where Thrift struct fields with multi-line collection defaults (`list`/`map`/`set` spanning several lines) were emitted with broken indentation — inner lines stuck at 4 cols, closing brackets at col 0, and any subsequent field in the same struct also collapsed to col 0.
- Trace the bug to a three-layer cascade between the AST parser, the AST index, and the struct formatter; fix all three so the AST faithfully describes multi-line fields and the formatter re-indents continuation lines and closing brackets.

## What changed

- `packages/core/src/ast/parser.ts`: replace `parseStructBody` with a custom loop that, after the existing single-line `parseStructFieldLine` identifies a field, runs a character-level scan tracking `<>`/`[]`/`{}`/`()` depths plus string literals and `//`/`#`/`/* */` comments (without touching the tokenizer's cross-line state) to compute the field's true end line and extends `field.range.end` accordingly. The new loop also handles same-line `struct Foo { ... }` correctly and recovers from malformed input by terminating a field early when the next non-empty line starts a new `\d+:` field.
- `packages/core/src/formatter/ast-index.ts`: expose `structFieldEnds: Map<startLine, endLine>` and map every line in `[start, end]` to the field so continuation lines no longer fall into the formatter's fallback path.
- `packages/core/src/formatter/struct-content.ts`: when at a multi-line field start, slice the source span `lines.slice(start, end+1).join('\n')` and pass it to `buildStructFieldFromAst`; for continuation lines, swallow them silently. Return `skipToIndex` so the outer loop skips consumed lines.
- `packages/core/src/formatter/formatter-core.ts`: forward `sourceLines` and `structFieldEnds`, and honour `skipToIndex` in the main per-line loop.
- `packages/core/src/formatter/field-parser.ts`: add `buildMultiLineStructFieldFromAst`, which separates trailing annotation and `,`/`;`, preserves `\n` between default-value parts, and trims middle lines so the output stage can re-indent them.
- `packages/core/src/formatter/struct-format.ts`: route multi-line fields through `formatMultiLineStructField`, which emits the header on the first line, re-indents middle lines to `indentLevel + 1`, places the closing bracket + annotation + trailing punctuation on a final line at `indentLevel`, and falls back to verbatim emission when the default is a backslash-continued string literal. Multi-line fields are excluded from annotation/content-width alignment math since their annotation lives on the last line.
- `tests/fixtures/golden/annotation-edge-cases.formatted.thrift`: regenerated; the previous golden captured the buggy output.

## Before / after

Source (`test-files/formatted.thrift`, lines 14–25):

```
3: list<map<string,set<i32>>> deepNested = [
{"set1": [1, 2], "set2": [3, 4]},
{"set3": [5, 6], "set4": [7, 8]}
] (description="Deep nested structure")
```

After fix:

```
    3: list<map<string,set<i32>>> deepNested = [
        {"set1": [1, 2], "set2": [3, 4]},
        {"set3": [5, 6], "set4": [7, 8]}
    ] (description="Deep nested structure")
```

## Test plan

- [x] `pnpm run build:core && pnpm run lint && pnpm test` — 1093 passing, 0 failing, lint clean.
- [x] End-to-end check on `test-files/formatted.thrift`: `NestedCollections`, `MultiLineDefaults`, and `CollectionStyles` produce the expected indentation; second pass is byte-identical (idempotent).
- [x] Single-line struct (`struct A { 1: i32 a }` repeated 100×) still parses as 100 top-level structs (boundary-conditions suite).
- [x] Malformed source (unclosed `<` followed by a new `\d+:` field) no longer absorbs the next field into the previous one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)