### PR TITLE
ci: align publish tag check with release-please monorepo tag naming

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,9 +65,14 @@ jobs:
       - name: Check tag exists for workflow_run
         id: chk
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PKG_VERSION: ${{ steps.pkg.outputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            V="v${{ steps.pkg.outputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            # release-please runs in monorepo mode; the root package's tag is
+            # prefixed with the package name (see release-please-config.json).
+            V="thrift-support-v${PKG_VERSION}"
             if git ls-remote --tags origin | grep -q "refs/tags/${V}$"; then
               echo "Tag ${V} exists on origin." >&2
               echo "should_publish=true" >> "$GITHUB_OUTPUT"
@@ -96,7 +101,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: thrift-support-${{ needs.package.outputs.version }}.vsix
-          tag_name: v${{ needs.package.outputs.version }}
+          tag_name: thrift-support-v${{ needs.package.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -104,8 +109,8 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ needs.package.outputs.version }}
-          name: v${{ needs.package.outputs.version }}
+          tag_name: thrift-support-v${{ needs.package.outputs.version }}
+          name: thrift-support-v${{ needs.package.outputs.version }}
           target_commitish: ${{ github.sha }}
           generate_release_notes: true
           files: thrift-support-${{ needs.package.outputs.version }}.vsix

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,10 +2,12 @@
   "commit-search-depth": 200,
   "release-search-depth": 50,
   "sequential-calls": true,
+  "pull-request-title-pattern": "chore${scope}: release ${component} ${version}",
   "packages": {
     ".": {
       "release-type": "node",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "component": "thrift-support"
     },
     "packages/core": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- **Bug**: After PR #53 merged, [run 26641198017](https://github.com/tzzs/vsce-thrift-support/actions/runs/26641198017) skipped every downstream publish job — `github_release`, `vsce_publish`, `openvsx_publish`, `npm_publish` all showed `-` (0s). The `package` job logged `Tag v3.0.0 does not exist on origin. Skipping publish.` → `should_publish=false` → `if:` short-circuit on every dependent job.
- **Root cause**: release-please runs in **monorepo mode** (3 packages in [release-please-config.json](release-please-config.json)). It creates component-prefixed tags — `thrift-support-v$VERSION` (root), `core-v$VERSION`, `cli-v$VERSION`. The existing remote tag `thrift-support-v2.2.1` confirms this. But [publish.yml](.github/workflows/publish.yml) was looking for `v$VERSION`, so the check could never succeed under `workflow_run`.
- **Fix**: Align the workflow's tag expectations with what release-please actually produces, and pin the component name explicitly so the contract is in config rather than inferred from `package.json.name`.

## Changes

### `.github/workflows/publish.yml`
- `Check tag exists for workflow_run` now looks for `thrift-support-v${PKG_VERSION}` instead of `v${PKG_VERSION}`.
- `Upload VSIX to GitHub Release` (both `workflow_run` and `workflow_dispatch` branches) uses the same `thrift-support-v${VERSION}` `tag_name` — this is the tag release-please creates, and the one we want to attach the `.vsix` to.
- Hardened the `Check tag exists` step by routing `github.event_name` and the package version through `env:` rather than embedding `${{ }}` directly in `run:` shell — matches [GitHub's workflow injection guidance](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/). No behavior change, just hardening (the source is `package.json`, not user input, but the pattern is brittle to future copy-paste).

### `release-please-config.json`
- Added `component: "thrift-support"` to the root package. Previously the root tag prefix was inferred from `package.json.name` — now it's contractual, so changing the package name won't silently break the publish chain.
- Added `pull-request-title-pattern: "chore${scope}: release ${component} ${version}"`. This eliminates the release-please warnings observed in [run 26641133561](https://github.com/tzzs/vsce-thrift-support/actions/runs/26641133561):
  - `⚠ pullRequestTitlePattern miss the part of '${version}'`
  - `✖ Pull request should have included version`
  - `⚠ Failed to find version in release notes`

## Not in this PR — manual follow-up to publish v3.0.0

`v3.0.0` is already on `master` (PR #53 bumped all three `package.json` files), but no tags were ever created. To actually publish 3.0.0 after this fix lands, do the following on the master HEAD (`89e5159`):

```bash
git tag thrift-support-v3.0.0 89e5159
git tag core-v3.0.0 89e5159
git tag cli-v3.0.0 89e5159
git push origin thrift-support-v3.0.0 core-v3.0.0 cli-v3.0.0

# Trigger publish manually (workflow_dispatch path bypasses the tag-exists check
# but the GH-release step will now reference the correct tag name)
gh workflow run publish.yml --ref master
```

From the next release onwards, release-please should create these tags itself.

## Test plan

- [ ] Merge this PR
- [ ] Manually create the three `*-v3.0.0` tags on `master` HEAD as shown above
- [ ] Run `gh workflow run publish.yml --ref master` and confirm all 5 jobs (`package`, `github_release`, `vsce_publish`, `openvsx_publish`, `npm_publish`) execute (not skipped)
- [ ] Verify `thrift-support-v3.0.0` GitHub Release contains the `.vsix`
- [ ] Verify VS Marketplace / Open VSX / npm received `3.0.0`
- [ ] On the next conventional-commit landing, confirm release-please opens a release PR with a title matching `chore(...): release ... <version>` (no more "missing version" warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)