### PR TITLE
ci: add stale and auto-label workflows for issue/PR automation

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,98 @@
+name: auto-label
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Auto-label issues
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.issue.title.toLowerCase();
+            const body = (context.payload.issue.body || '').toLowerCase();
+
+            const labels = [];
+
+            // Bug detection: title or body contains bug-related keywords
+            if (title.startsWith('bug') || title.startsWith('fix:') || title.startsWith('fix(') ||
+                title.includes('broken') || title.includes('error') || title.includes('crash') ||
+                title.includes('incorrect') || title.includes('fail') || title.includes('bug')) {
+              labels.push('bug');
+            }
+
+            // Enhancement detection: title contains feature-related keywords
+            if (title.startsWith('feat:') || title.startsWith('feat(') ||
+                title.startsWith('feature:') || title.startsWith('enhancement:') ||
+                title.includes('feature request') || title.includes('request') ||
+                body.includes('feature request')) {
+              labels.push('enhancement');
+            }
+
+            // Heuristic: if body contains typical bug report patterns
+            if (!labels.includes('bug') && !labels.includes('enhancement')) {
+              if (body.includes('steps to reproduce') || body.includes('expected behavior') ||
+                  body.includes('actual behavior') || body.includes('reproduction steps')) {
+                labels.push('bug');
+              }
+            }
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                labels: labels
+              });
+              console.log(`Added labels: ${labels.join(', ')}`);
+            } else {
+              console.log('No matching labels found');
+            }
+
+      - name: Auto-label PRs
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title.toLowerCase();
+            const labels = [];
+
+            // PR with fix: or fix( prefix → bug
+            if (title.startsWith('fix:') || title.startsWith('fix(') ||
+                title.startsWith('bug:') || title.startsWith('bug(') ||
+                title.startsWith('hotfix:') || title.startsWith('hotfix(')) {
+              labels.push('bug');
+            }
+
+            // PR with feat: or feat( prefix → enhancement
+            if (title.startsWith('feat:') || title.startsWith('feat(') ||
+                title.startsWith('feature:') || title.startsWith('feature(') ||
+                title.startsWith('enhancement:') || title.startsWith('enhancement(')) {
+              labels.push('enhancement');
+            }
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: labels
+              });
+              console.log(`Added labels: ${labels.join(', ')}`);
+            } else {
+              console.log('No matching labels found');
+            }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,112 @@
+name: stale
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: issues
+            days-before-issue-stale: 30
+            days-before-issue-close: 14
+            days-before-pr-stale: -1
+            days-before-pr-close: -1
+            exempt-issue-labels: bug,enhancement,needs-info,waiting-for-author,pinned
+            stale-issue-message: |
+              This issue has been automatically marked as stale due to 30 days of inactivity.
+              It will be closed in 14 days if no further activity occurs.
+              If you believe this issue is still relevant, please leave a comment.
+            close-issue-message: |
+              This issue has been automatically closed due to extended inactivity.
+              Feel free to reopen if the issue persists or is still relevant.
+
+          - name: enhancements
+            days-before-issue-stale: 90
+            days-before-issue-close: 30
+            days-before-pr-stale: -1
+            days-before-pr-close: -1
+            any-of-issue-labels: enhancement
+            stale-issue-message: |
+              This enhancement request has been automatically marked as stale due to 90 days of inactivity.
+              It will be closed in 30 days if no further activity occurs.
+              If you believe this is still relevant, please leave a comment.
+            close-issue-message: |
+              This enhancement request has been automatically closed due to extended inactivity.
+              Feel free to reopen if this is still desired.
+
+          - name: bugs
+            days-before-issue-stale: 60
+            days-before-issue-close: -1
+            days-before-pr-stale: -1
+            days-before-pr-close: -1
+            any-of-issue-labels: bug
+            exempt-issue-labels: enhancement
+            stale-issue-message: |
+              This bug report has been automatically marked as stale due to 60 days of inactivity.
+              Bugs are never automatically closed, but maintainers may close them manually if no longer reproducible.
+              Please update if this issue is still relevant.
+
+          - name: needs-info
+            days-before-issue-stale: 7
+            days-before-issue-close: 3
+            days-before-pr-stale: -1
+            days-before-pr-close: -1
+            any-of-issue-labels: needs-info,waiting-for-author
+            exempt-issue-labels: bug,enhancement
+            stale-issue-message: |
+              This issue requires more information from the author and has not had activity for 7 days.
+              It will be closed in 3 days if the requested information is not provided.
+            close-issue-message: |
+              This issue has been automatically closed due to lack of requested information.
+              Feel free to reopen with the requested details.
+
+          - name: prs
+            days-before-issue-stale: -1
+            days-before-issue-close: -1
+            days-before-pr-stale: 60
+            days-before-pr-close: 14
+            exempt-pr-labels: pinned,security
+            stale-pr-message: |
+              This pull request has been automatically marked as stale due to 60 days of inactivity.
+              It will be closed in 14 days if no further activity occurs.
+            close-pr-message: |
+              This pull request has been automatically closed due to extended inactivity.
+              Feel free to reopen or create a new PR if you'd like to continue working on this.
+
+    steps:
+      - name: Stale (${{ matrix.name }})
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: ${{ matrix.days-before-issue-stale }}
+          days-before-issue-close: ${{ matrix.days-before-issue-close }}
+          days-before-pr-stale: ${{ matrix.days-before-pr-stale }}
+          days-before-pr-close: ${{ matrix.days-before-pr-close }}
+          any-of-issue-labels: ${{ matrix.any-of-issue-labels || '' }}
+          exempt-issue-labels: ${{ matrix.exempt-issue-labels || '' }}
+          exempt-pr-labels: ${{ matrix.exempt-pr-labels || '' }}
+          stale-issue-message: ${{ matrix.stale-issue-message || '' }}
+          close-issue-message: ${{ matrix.close-issue-message || '' }}
+          stale-pr-message: ${{ matrix.stale-pr-message || '' }}
+          close-pr-message: ${{ matrix.close-pr-message || '' }}
+          close-issue-reason: not_planned
+          stale-issue-label: stale
+          stale-pr-label: stale
+          labels-to-remove-when-unstale: stale
+          labels-to-add-when-stale: stale
+          remove-stale-when-updated: true
+          operations-per-run: 200

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ test-thrift/
 .trae/
 .pnpm-store/
 
+# Git worktrees
+.worktree/
+.worktrees/
+
 # Prevent compiled output from being committed into source directories
 packages/*/src/**/*.js
 packages/*/src/**/*.js.map


### PR DESCRIPTION
## Summary

添加 Issue/PR 自动提醒、自动关闭和自动打标的 GitHub Actions：

- **`stale.yml`** — 矩阵驱动，5 种过期规则：
  - 普通 Issue：30 天 stale → 14 天后关闭
  - Enhancement：90 天 stale → 30 天后关闭
  - Bug：60 天 stale，**永不自动关闭**
  - Needs-info：7 天 stale → 3 天后关闭
  - PR：60 天 stale → 14 天后关闭（exempt `pinned`/`security`）
- **`auto-label.yml`** — Issue/PR 创建时自动打标：
  - `bug`：标题含 bug/fix/crash/error 等关键词
  - `enhancement`：标题含 feat/feature/enhancement 等关键词
  - PR：Conventional Commits (`fix:` → `bug`, `feat:` → `enhancement`)

## Design Doc

详见 `docs/superpowers/specs/2026-05-29-stale-automation-design.md`

## Test Plan

- [ ] YAML 语法验证通过（`python3 -c "import yaml; yaml.safe_load(...)"`）
- [ ] 现有 workflow（ci/publish/release-please）不受影响
- [ ] 合并后在 Actions 页面确认 `stale` 和 `auto-label` 新 workflow 可见
- [ ] 等待首次 schedule 运行，验证 stale 规则是否按预期执行