### PR TITLE
refactor: centralize shared config schema

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -4,26 +4,12 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import type {DiagnosticsRuleOptions, ThriftFormattingOptions} from '@tanzz/thrift-core';
+import {findUnknownConfigKeys} from '@tanzz/thrift-core';
+import type {DiagnosticsRuleOptions, SharedThriftConfig, ThriftFormattingOptions} from '@tanzz/thrift-core';
 
 const CONFIG_FILENAME = '.thriftrc.json';
-const TOP_LEVEL_KEYS = new Set(['format', 'lint', 'diagnostics']);
-const FORMAT_KEYS = new Set([
-    'indentSize',
-    'maxLineLength',
-    'trailingComma',
-    'collectionStyle',
-    'alignTypes',
-    'alignNames',
-    'alignAssignments',
-    'alignStructDefaults',
-    'alignAnnotations',
-    'alignComments'
-]);
-const LINT_KEYS = new Set(['severity']);
-const DIAGNOSTICS_KEYS = new Set(['rules']);
 
-export interface ThriftCliConfig {
+export interface ThriftCliConfig extends SharedThriftConfig {
     format?: Partial<ThriftFormattingOptions>;
     lint?: {
         severity?: 'error' | 'warning' | 'all';
@@ -67,19 +53,8 @@ export function loadConfig(configPath: string): ThriftCliConfig {
 }
 
 function warnUnknownConfigKeys(config: ThriftCliConfig, configPath: string): void {
-    warnUnknownKeys(Object.keys(config), TOP_LEVEL_KEYS, configPath);
-    warnUnknownKeys(Object.keys(config.format ?? {}), FORMAT_KEYS, configPath, 'format');
-    warnUnknownKeys(Object.keys(config.lint ?? {}), LINT_KEYS, configPath, 'lint');
-    warnUnknownKeys(Object.keys(config.diagnostics ?? {}), DIAGNOSTICS_KEYS, configPath, 'diagnostics');
-}
-
-function warnUnknownKeys(keys: string[], knownKeys: Set<string>, configPath: string, section?: string): void {
-    for (const key of keys) {
-        if (knownKeys.has(key)) {
-            continue;
-        }
-        const fullKey = section === undefined ? key : `${section}.${key}`;
-        process.stderr.write(`Warning: Unknown config key "${fullKey}" in ${configPath}\n`);
+    for (const key of findUnknownConfigKeys(config)) {
+        process.stderr.write(`Warning: Unknown config key "${key}" in ${configPath}\n`);
     }
 }
 

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1,0 +1,151 @@
+import type {DiagnosticsRuleOptions} from '../diagnostics/rules/registry';
+import type {ThriftFormattingOptions} from '../interfaces.types';
+
+type SharedConfigType = 'boolean' | 'number' | 'string' | 'object';
+
+interface SharedConfigEntry<T = unknown> {
+    type: SharedConfigType;
+    default?: T;
+    enum?: readonly T[];
+    min?: number;
+    max?: number;
+}
+
+type SharedConfigSection = Record<string, SharedConfigEntry>;
+
+export interface SharedConfigSchema {
+    format: SharedConfigSection;
+    lint: SharedConfigSection;
+    diagnostics: SharedConfigSection;
+}
+
+export interface SharedConfigValidationResult {
+    valid: boolean;
+    error?: string;
+}
+
+export interface SharedThriftConfig {
+    format?: Partial<ThriftFormattingOptions> & {
+        alignNames?: boolean;
+        alignAssignments?: boolean;
+        alignFieldNames?: boolean;
+        alignEnumNames?: boolean;
+        alignEnumEquals?: boolean;
+        alignEnumValues?: boolean;
+        alignStructAnnotations?: boolean;
+    };
+    lint?: {
+        severity?: 'error' | 'warning' | 'all';
+    };
+    diagnostics?: DiagnosticsRuleOptions;
+}
+
+export const DEFAULT_FORMAT_CONFIG: ThriftFormattingOptions = {
+    trailingComma: 'preserve',
+    alignTypes: true,
+    alignFieldNames: true,
+    alignStructDefaults: false,
+    alignAnnotations: true,
+    alignComments: true,
+    alignEnumNames: true,
+    alignEnumEquals: true,
+    alignEnumValues: true,
+    indentSize: 4,
+    maxLineLength: 100,
+    collectionStyle: 'preserve',
+    insertSpaces: true,
+    tabSize: 4
+};
+
+export const SHARED_CONFIG_SCHEMA: SharedConfigSchema = {
+    format: {
+        trailingComma: {type: 'string', default: 'preserve', enum: ['preserve', 'add', 'remove']},
+        alignTypes: {type: 'boolean', default: true},
+        alignNames: {type: 'boolean', default: true},
+        alignAssignments: {type: 'boolean', default: true},
+        alignFieldNames: {type: 'boolean', default: true},
+        alignStructDefaults: {type: 'boolean', default: false},
+        alignAnnotations: {type: 'boolean', default: true},
+        alignStructAnnotations: {type: 'boolean', default: true},
+        alignComments: {type: 'boolean', default: true},
+        alignEnumNames: {type: 'boolean', default: true},
+        alignEnumEquals: {type: 'boolean', default: true},
+        alignEnumValues: {type: 'boolean', default: true},
+        indentSize: {type: 'number', default: 4, min: 1, max: 8},
+        maxLineLength: {type: 'number', default: 100, min: 40, max: 200},
+        collectionStyle: {type: 'string', default: 'preserve', enum: ['preserve', 'multiline', 'auto']}
+    },
+    lint: {
+        severity: {type: 'string', default: 'all', enum: ['error', 'warning', 'all']}
+    },
+    diagnostics: {
+        debug: {type: 'boolean', default: false},
+        rules: {type: 'object', default: {}}
+    }
+};
+
+export function findUnknownConfigKeys(config: SharedThriftConfig | Record<string, unknown>): string[] {
+    const unknown: string[] = [];
+    const record = config as Record<string, unknown>;
+    collectUnknownSectionKeys(record, 'format', unknown);
+    collectUnknownSectionKeys(record, 'lint', unknown);
+    collectUnknownSectionKeys(record, 'diagnostics', unknown);
+    for (const key of Object.keys(record)) {
+        if (!(key in SHARED_CONFIG_SCHEMA)) {
+            unknown.push(key);
+        }
+    }
+    return unknown;
+}
+
+export function validateSharedConfigValue(key: string, value: unknown): SharedConfigValidationResult {
+    const entry = getSchemaEntry(key);
+    if (entry === undefined) {
+        return {valid: true};
+    }
+    if (entry.type === 'object') {
+        if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+            return {valid: false, error: `${key} must be an object`};
+        }
+        return {valid: true};
+    }
+    if (typeof value !== entry.type) {
+        return {valid: false, error: `${key} must be a ${entry.type}`};
+    }
+    if (typeof value === 'number') {
+        if (typeof entry.min === 'number' && value < entry.min) {
+            return {valid: false, error: `${key} must be at least ${entry.min}`};
+        }
+        if (typeof entry.max === 'number' && value > entry.max) {
+            return {valid: false, error: `${key} must be at most ${entry.max}`};
+        }
+    }
+    if (entry.enum !== undefined && !entry.enum.includes(value)) {
+        return {valid: false, error: `${key} must be one of: ${entry.enum.join(', ')}`};
+    }
+    return {valid: true};
+}
+
+function collectUnknownSectionKeys(record: Record<string, unknown>, section: keyof SharedConfigSchema, unknown: string[]): void {
+    const value = record[section];
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return;
+    }
+    const sectionSchema = SHARED_CONFIG_SCHEMA[section];
+    for (const key of Object.keys(value)) {
+        if (!(key in sectionSchema)) {
+            unknown.push(`${section}.${key}`);
+        }
+    }
+}
+
+function getSchemaEntry(key: string): SharedConfigEntry | undefined {
+    const [section, setting, ...rest] = key.split('.');
+    if (rest.length > 0 || setting === undefined) {
+        return undefined;
+    }
+    if (section !== 'format' && section !== 'lint' && section !== 'diagnostics') {
+        return undefined;
+    }
+    return SHARED_CONFIG_SCHEMA[section][setting];
+}

--- a/packages/core/src/formatter/formatter-core.ts
+++ b/packages/core/src/formatter/formatter-core.ts
@@ -41,25 +41,9 @@ import {normalizeGenericsInSignature, splitTopLevelParts} from './text-utils';
 import {createLineRange, LineRange} from '../utils/line-range';
 import {hashContent} from '../utils/cache-expiry';
 import {ErrorHandler} from '../utils/error-handler';
+import {DEFAULT_FORMAT_CONFIG} from '../config/schema';
 
 const formatErrorHandler = new ErrorHandler();
-
-const DEFAULT_FORMAT_OPTIONS: ThriftFormattingOptions = {
-    trailingComma: 'preserve',
-    alignTypes: true,
-    alignFieldNames: true,
-    alignStructDefaults: false,
-    alignAnnotations: true,
-    alignComments: true,
-    alignEnumNames: true,
-    alignEnumEquals: true,
-    alignEnumValues: true,
-    indentSize: 4,
-    maxLineLength: 100,
-    collectionStyle: 'preserve',
-    insertSpaces: true,
-    tabSize: 4
-};
 
 /**
  * Format Thrift source with unified rules.
@@ -70,7 +54,7 @@ const DEFAULT_FORMAT_OPTIONS: ThriftFormattingOptions = {
  */
 export function formatThriftContent(
     content: string,
-    options: ThriftFormattingOptions = DEFAULT_FORMAT_OPTIONS,
+    options: ThriftFormattingOptions = DEFAULT_FORMAT_CONFIG,
     dirtyRange?: LineRange
 ): string {
     const lines = content.split(/\r?\n/);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,8 @@ export {
 // Config defaults
 export {config, config as defaultConfig, cacheConfig, memoryConfig} from './config/index';
 export type {CacheConfig, CacheEntry, MemoryConfig} from './config/index';
+export {DEFAULT_FORMAT_CONFIG, SHARED_CONFIG_SCHEMA, findUnknownConfigKeys, validateSharedConfigValue} from './config/schema';
+export type {SharedConfigSchema, SharedConfigValidationResult, SharedThriftConfig} from './config/schema';
 export {CACHE_CONFIGS, getAllCacheConfigs, updateCacheConfig, validateCacheConfig, registerAllCacheConfigs} from './config/cache-config';
 
 // Utils - line range

--- a/packages/vscode/src/config/service.ts
+++ b/packages/vscode/src/config/service.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import {CacheConfig, CacheManagerConfig, config, MemoryConfig} from '@tanzz/thrift-core';
 import {getAllCacheConfigs, updateCacheConfig} from '@tanzz/thrift-core';
+import {validateSharedConfigValue} from '@tanzz/thrift-core';
 
 /**
  * 配置变更事件
@@ -177,56 +178,7 @@ export class ConfigService {
      * @returns 验证结果
      */
     validate(key: string, value: unknown): {valid: boolean; error?: string} {
-        if (key === 'format.indentSize') {
-            if (typeof value !== 'number') {
-                return {valid: false, error: 'Indent size must be a number'};
-            }
-            if (value < 1 || value > 8) {
-                return {valid: false, error: 'Indent size must be between 1 and 8'};
-            }
-            return {valid: true};
-        }
-        if (key === 'format.maxLineLength') {
-            if (typeof value !== 'number') {
-                return {valid: false, error: 'Max line length must be a number'};
-            }
-            if (value < 40 || value > 200) {
-                return {valid: false, error: 'Max line length must be between 40 and 200'};
-            }
-            return {valid: true};
-        }
-        if (key === 'format.trailingComma') {
-            if (typeof value !== 'string') {
-                return {valid: false, error: 'Trailing comma must be a string'};
-            }
-            const validValues = ['preserve', 'add', 'remove'];
-            if (!validValues.includes(value)) {
-                return {valid: false, error: `Trailing comma must be one of: ${validValues.join(', ')}`};
-            }
-            return {valid: true};
-        }
-        const booleanKeys = [
-            'format.alignTypes', 'format.alignNames', 'format.alignAssignments',
-            'format.alignStructDefaults', 'format.alignAnnotations', 'format.alignComments',
-            'diagnostics.debug'
-        ];
-        if (booleanKeys.includes(key)) {
-            if (typeof value !== 'boolean') {
-                return {valid: false, error: `${key} must be a boolean`};
-            }
-            return {valid: true};
-        }
-        if (key === 'format.collectionStyle') {
-            if (typeof value !== 'string') {
-                return {valid: false, error: 'Collection style must be a string'};
-            }
-            const validValues = ['preserve', 'multiline', 'auto'];
-            if (!validValues.includes(value)) {
-                return {valid: false, error: `Collection style must be one of: ${validValues.join(', ')}`};
-            }
-            return {valid: true};
-        }
-        return {valid: true};
+        return validateSharedConfigValue(key, value);
     }
 
     /**

--- a/packages/vscode/src/formatting-bridge/options.ts
+++ b/packages/vscode/src/formatting-bridge/options.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import {ThriftFormattingOptions} from '@tanzz/thrift-core';
+import {DEFAULT_FORMAT_CONFIG, ThriftFormattingOptions} from '@tanzz/thrift-core';
 import {FormattingContext} from './context';
 
 interface FormattingOptionDeps {
@@ -40,7 +40,7 @@ export function resolveFormattingOptions(
     const cfgAlignNames = getOpt<boolean | undefined>('alignNames', undefined);
     const alignNames = (typeof cfgAlignNames !== 'undefined')
         ? cfgAlignNames
-        : (getOpt('alignFieldNames', undefined) ?? getOpt('alignEnumNames', undefined) ?? true);
+        : (getOpt('alignFieldNames', undefined) ?? getOpt('alignEnumNames', undefined) ?? DEFAULT_FORMAT_CONFIG.alignFieldNames);
     const alignAssignments = getOpt<boolean | undefined>('alignAssignments', undefined);
     const cfgAlignStructDefaults = getOpt<boolean | undefined>('alignStructDefaults', undefined);
     const cfgAlignEnumEquals = getOpt<boolean | undefined>('alignEnumEquals', undefined);
@@ -48,39 +48,39 @@ export function resolveFormattingOptions(
     const cfgAlignAnnotations = getOpt<boolean | undefined>('alignAnnotations', undefined);
     const resolvedAlignAnnotations = (typeof cfgAlignAnnotations !== 'undefined')
         ? cfgAlignAnnotations
-        : getOpt('alignStructAnnotations', true);
+        : getOpt('alignStructAnnotations', DEFAULT_FORMAT_CONFIG.alignAnnotations);
 
     const resolvedAlignStructDefaults = (typeof cfgAlignStructDefaults !== 'undefined')
         ? cfgAlignStructDefaults
-        : false;
+        : DEFAULT_FORMAT_CONFIG.alignStructDefaults;
     const resolvedAlignEnumEquals = (typeof cfgAlignEnumEquals !== 'undefined')
         ? cfgAlignEnumEquals
         : (typeof alignAssignments === 'boolean')
             ? alignAssignments
-            : true;
+            : DEFAULT_FORMAT_CONFIG.alignEnumEquals;
     const resolvedAlignEnumValues = (typeof cfgAlignEnumValues !== 'undefined')
         ? cfgAlignEnumValues
         : (typeof alignAssignments === 'boolean')
             ? alignAssignments
-            : true;
+            : DEFAULT_FORMAT_CONFIG.alignEnumValues;
 
     const indentSize = typeof options.indentSize === 'number'
         ? options.indentSize
-        : getOpt('indentSize', 4);
+        : getOpt('indentSize', DEFAULT_FORMAT_CONFIG.indentSize);
 
     return {
-        trailingComma: getOpt('trailingComma', 'preserve'),
-        alignTypes: getOpt('alignTypes', true),
+        trailingComma: getOpt('trailingComma', DEFAULT_FORMAT_CONFIG.trailingComma),
+        alignTypes: getOpt('alignTypes', DEFAULT_FORMAT_CONFIG.alignTypes),
         alignFieldNames: alignNames,
         alignStructDefaults: resolvedAlignStructDefaults,
         alignAnnotations: resolvedAlignAnnotations,
-        alignComments: getOpt('alignComments', true),
+        alignComments: getOpt('alignComments', DEFAULT_FORMAT_CONFIG.alignComments),
         alignEnumNames: alignNames,
         alignEnumEquals: resolvedAlignEnumEquals,
         alignEnumValues: resolvedAlignEnumValues,
         indentSize,
-        maxLineLength: getOpt('maxLineLength', 100),
-        collectionStyle: getOpt('collectionStyle', 'preserve'),
+        maxLineLength: getOpt('maxLineLength', DEFAULT_FORMAT_CONFIG.maxLineLength),
+        collectionStyle: getOpt('collectionStyle', DEFAULT_FORMAT_CONFIG.collectionStyle),
         insertSpaces: options.insertSpaces,
         tabSize: options.tabSize,
         initialContext

--- a/tests/cli/test-cli-units.js
+++ b/tests/cli/test-cli-units.js
@@ -189,11 +189,13 @@ describe('CLI unit tests', () => {
             const d = tmpDir('cli-load-unknown-');
             try {
                 const cfg = path.join(d, '.thriftrc.json');
-                fs.writeFileSync(cfg, '{"format":{"indentSize":2,"unknown":true},"mystery":1}');
+                fs.writeFileSync(cfg, '{"format":{"indentSize":2,"alignFieldNames":true,"unknown":true},"mystery":1}');
                 const o = captureOutput(() => configMod.loadConfig(cfg));
                 assert.strictEqual(o.returned.format.indentSize, 2);
+                assert.strictEqual(o.returned.format.alignFieldNames, true);
                 assert.ok(o.stderr.includes('Unknown config key "format.unknown"'));
                 assert.ok(o.stderr.includes('Unknown config key "mystery"'));
+                assert.ok(!o.stderr.includes('Unknown config key "format.alignFieldNames"'));
             } finally {
                 fs.rmSync(d, {recursive: true});
             }

--- a/tests/src/config/test-config-service.js
+++ b/tests/src/config/test-config-service.js
@@ -201,6 +201,18 @@ describe('ConfigService', () => {
             });
         });
 
+        describe('shared schema validation', () => {
+            it('should validate lint severity from the core schema', () => {
+                assert.strictEqual(svc.validate('lint.severity', 'warning').valid, true);
+                assert.strictEqual(svc.validate('lint.severity', 'debug').valid, false);
+            });
+
+            it('should validate diagnostics rules from the core schema', () => {
+                assert.strictEqual(svc.validate('diagnostics.rules', {}).valid, true);
+                assert.strictEqual(svc.validate('diagnostics.rules', false).valid, false);
+            });
+        });
+
         it('should return valid for unknown keys (loose validation)', () => {
             const result = svc.validate('some.unknown.key', 'anything');
             assert.strictEqual(result.valid, true);

--- a/tests/src/config/test-shared-config-schema.js
+++ b/tests/src/config/test-shared-config-schema.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+
+const {
+    DEFAULT_FORMAT_CONFIG,
+    SHARED_CONFIG_SCHEMA,
+    findUnknownConfigKeys,
+    validateSharedConfigValue
+} = require('../../../out/config/schema.js');
+
+describe('Shared config schema', () => {
+    it('defines shared format, lint, and diagnostics keys', () => {
+        assert.strictEqual(DEFAULT_FORMAT_CONFIG.trailingComma, 'preserve');
+        assert.strictEqual(DEFAULT_FORMAT_CONFIG.alignStructDefaults, false);
+        assert.ok(SHARED_CONFIG_SCHEMA.format.alignAssignments);
+        assert.ok(SHARED_CONFIG_SCHEMA.format.alignFieldNames);
+        assert.ok(SHARED_CONFIG_SCHEMA.lint.severity);
+        assert.ok(SHARED_CONFIG_SCHEMA.diagnostics.rules);
+    });
+
+    it('finds unknown keys without flagging known nested keys', () => {
+        const unknown = findUnknownConfigKeys({
+            format: {
+                indentSize: 2,
+                alignFieldNames: true,
+                nope: true
+            },
+            lint: {
+                severity: 'warning',
+                extra: true
+            },
+            diagnostics: {
+                rules: {},
+                extra: true
+            },
+            mystery: 1
+        });
+
+        assert.deepStrictEqual(unknown, [
+            'format.nope',
+            'lint.extra',
+            'diagnostics.extra',
+            'mystery'
+        ]);
+    });
+
+    it('validates shared values consistently', () => {
+        assert.deepStrictEqual(validateSharedConfigValue('format.indentSize', 2), {valid: true});
+        assert.strictEqual(validateSharedConfigValue('format.indentSize', 0).valid, false);
+        assert.strictEqual(validateSharedConfigValue('format.trailingComma', 'always').valid, false);
+        assert.strictEqual(validateSharedConfigValue('lint.severity', 'debug').valid, false);
+        assert.strictEqual(validateSharedConfigValue('diagnostics.rules', {}).valid, true);
+        assert.strictEqual(validateSharedConfigValue('unknown.key', 'anything').valid, true);
+    });
+});


### PR DESCRIPTION
## Summary
- add shared config schema/defaults in packages/core for format, lint, and diagnostics settings
- route CLI .thriftrc unknown-key warnings through the core schema
- route VS Code config validation and formatting defaults through the shared schema while preserving existing fallback behavior

## Test Plan
- npm run lint:fix
- npm run lint
- npm run build (blocked by local pnpm shim: missing pnpm v10.25.0 binary under .pnpm-store)
- node node_modules/.bin/eslint --cache 'packages/*/src/**/*.ts' --fix
- node node_modules/.bin/eslint --cache 'packages/*/src/**/*.ts'
- node node_modules/.bin/tsc -p packages/core/tsconfig.json
- node packages/cli/build.js
- node node_modules/.bin/tsc -p packages/cli/tsconfig.json
- node node_modules/.bin/tsc -p ./
- node build.js
- node node_modules/.bin/mocha --exit
- node node_modules/.bin/c8 --exclude 'packages/core/**' --exclude-after-remap --reporter text-summary --reporter lcov node node_modules/.bin/mocha --require ./tests/require-hook.js --no-config --timeout 30000 tests/cli/test-cli-integration.js tests/cli/test-cli-units.js