### PR TITLE
chore: categorize performance benchmark output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,31 @@ jobs:
           node packages/cli/dist/cli.js lint test-files/example-enum.thrift
           node packages/cli/dist/cli.js symbols test-files/example-enum.thrift
 
+  performance:
+    runs-on: ubuntu-latest
+    needs: checks
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
       - name: Performance benchmark
-        run: node -e "require('./tests/require-hook.js'); require('./tests/perf/run-performance-benchmark.js')" -- --structs 120 --fields 30 --iterations 5 --threshold-full-ms 400 --threshold-incremental-ms 100
+        run: pnpm run perf:benchmark:ci -- --structs 120 --fields 30
 
       - name: Performance assertions (multi-size)
         run: pnpm exec mocha --require tests/require-hook.js --timeout 120000 tests/perf/perf-assertions.js

--- a/package.json
+++ b/package.json
@@ -280,7 +280,9 @@
     "test:single": "pnpm run build && mocha --config .mocharc.single.json",
     "coverage": "pnpm run build && c8 --reporter text-summary --reporter lcov mocha",
     "coverage:cli": "pnpm --filter @tanzz/thrift-core run build && node packages/cli/build.js && pnpm exec tsc -p packages/cli/tsconfig.json && c8 --exclude 'packages/core/**' --exclude-after-remap --reporter text-summary --reporter lcov mocha --no-config --timeout 30000 tests/cli/test-cli-integration.js tests/cli/test-cli-units.js",
-    "perf:benchmark": "node tests/perf/run-performance-benchmark.js"
+    "perf:benchmark": "node tests/perf/run-performance-benchmark.js",
+    "perf:benchmark:json": "node tests/perf/run-performance-benchmark.js --json",
+    "perf:benchmark:ci": "node tests/perf/run-performance-benchmark.js --json --iterations 5 --threshold-full-ms 400 --threshold-incremental-ms 100"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/tests/perf/run-performance-benchmark.js
+++ b/tests/perf/run-performance-benchmark.js
@@ -15,6 +15,8 @@ const {DiagnosticManager} = require('../../out/diagnostics');
 const {ThriftFormattingProvider} = require('../../out/formatting-bridge/index.js');
 const {IncrementalTracker} = require('../../out/utils/incremental-tracker.js');
 const {config} = require('../../out/config/index.js');
+const {ThriftParser} = require('../../out/ast/parser.js');
+const {WorkspaceIndex} = require('../../out/indexing/workspace-index.js');
 
 function parseArg(flag, fallback) {
     const idx = process.argv.indexOf(flag);
@@ -61,7 +63,7 @@ function updateLines(text, updates) {
     return lines.join('\n');
 }
 
-async function measure(label, iterations, fn) {
+async function measure(category, operation, label, iterations, fn) {
     const durations = [];
     for (let i = 0; i < iterations; i += 1) {
         const start = performance.now();
@@ -75,7 +77,7 @@ async function measure(label, iterations, fn) {
     const sorted = [...durations].sort((a, b) => a - b);
     const p95 = sorted[Math.floor(sorted.length * 0.95)];
     logText(`${label}: avg ${avg.toFixed(2)}ms, p95 ${p95.toFixed(2)}ms (min ${min.toFixed(2)} / max ${max.toFixed(2)})`);
-    return {label, avg, min, max, p95};
+    return {category, operation, label, avg, min, max, p95};
 }
 
 async function run() {
@@ -97,6 +99,7 @@ async function run() {
     const manager = new DiagnosticManager();
     const tracker = IncrementalTracker.getInstance();
     const formattingProvider = new ThriftFormattingProvider({incrementalTracker: tracker});
+    const workspaceFiles = createWorkspaceIndexFiles(text);
 
     config.incremental.analysisEnabled = true;
     config.incremental.formattingEnabled = true;
@@ -106,12 +109,26 @@ async function run() {
 
     const results = [];
 
-    results.push(await measure('Diagnostics (full)', iterations, async () => {
+    results.push(await measure('parser', 'parse-full', 'Parser (full)', iterations, async () => {
+        new ThriftParser(text).parse();
+    }));
+
+    results.push(await measure('workspace-index', 'refresh', 'Workspace index (refresh)', iterations, async () => {
+        const index = new WorkspaceIndex({
+            findFiles: async () => Array.from(workspaceFiles.keys()).map(file => vscode.Uri.file(file)),
+            readFile: async uri => workspaceFiles.get(uri.fsPath) ?? '',
+            createWatcher: () => ({dispose() {}})
+        });
+        await index.refresh();
+        index.dispose();
+    }));
+
+    results.push(await measure('diagnostics', 'full', 'Diagnostics (full)', iterations, async () => {
         doc.version += 1;
         await manager.performAnalysis(doc);
     }));
 
-    results.push(await measure('Diagnostics (incremental)', iterations, async () => {
+    results.push(await measure('diagnostics', 'incremental', 'Diagnostics (incremental)', iterations, async () => {
         doc.version += 1;
         const updatedText = updateLines(text, [
             { line: 2, value: '  2: i32 field_0_2' },
@@ -135,11 +152,11 @@ async function run() {
         await manager.performAnalysis(updatedDoc);
     }));
 
-    results.push(await measure('Formatting (full)', iterations, async () => {
+    results.push(await measure('formatter', 'full', 'Formatting (full)', iterations, async () => {
         formattingProvider.provideDocumentFormattingEdits(doc, {insertSpaces: true, tabSize: 4});
     }));
 
-    results.push(await measure('Formatting (incremental)', iterations, async () => {
+    results.push(await measure('formatter', 'incremental', 'Formatting (incremental)', iterations, async () => {
         tracker.markChanges({
             document: doc,
             contentChanges: [
@@ -172,6 +189,7 @@ async function run() {
 
     if (jsonOutput) {
         process.stdout.write(JSON.stringify({
+            schemaVersion: 1,
             parameters: {
                 structCount,
                 fieldCount,
@@ -199,6 +217,13 @@ function logText(message) {
         return;
     }
     console.log(message);
+}
+
+function createWorkspaceIndexFiles(text) {
+    return new Map([
+        ['/tmp/perf-benchmark.thrift', 'include "shared.thrift"\n' + text],
+        ['/tmp/shared.thrift', 'namespace js shared\nstruct SharedType { 1: string id }\n']
+    ]);
 }
 
 run().catch((error) => {

--- a/tests/src/perf/test-benchmark-json-output.js
+++ b/tests/src/perf/test-benchmark-json-output.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const path = require('path');
+const {spawnSync} = require('child_process');
+
+describe('performance benchmark JSON output', function () {
+    this.timeout(30000);
+
+    it('emits categorized machine-readable benchmark results', () => {
+        const script = path.join(process.cwd(), 'tests/perf/run-performance-benchmark.js');
+        const result = spawnSync(process.execPath, [
+            script,
+            '--json',
+            '--structs', '4',
+            '--fields', '3',
+            '--iterations', '1'
+        ], {
+            cwd: process.cwd(),
+            encoding: 'utf8'
+        });
+
+        assert.strictEqual(result.status, 0, result.stderr);
+        const payload = JSON.parse(result.stdout);
+        assert.strictEqual(payload.schemaVersion, 1);
+        assert.ok(Array.isArray(payload.results));
+        assert.ok(payload.results.length >= 4);
+
+        const categories = new Set(payload.results.map(entry => entry.category));
+        assert.ok(categories.has('parser'));
+        assert.ok(categories.has('diagnostics'));
+        assert.ok(categories.has('formatter'));
+        assert.ok(categories.has('workspace-index'));
+
+        for (const entry of payload.results) {
+            assert.strictEqual(typeof entry.operation, 'string');
+            assert.strictEqual(typeof entry.avg, 'number');
+            assert.strictEqual(typeof entry.p95, 'number');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add categorized parser, diagnostics, formatter, and workspace-index metrics to perf benchmark JSON output
- add benchmark JSON structure regression coverage
- add perf benchmark JSON/CI npm scripts and move performance checks into an optional CI job

## Test Plan
- npm run lint:fix
- npm run lint
- npm run build (blocked by local pnpm shim: missing pnpm v10.25.0 binary under .pnpm-store)
- node node_modules/.bin/eslint --cache 'packages/*/src/**/*.ts' --fix
- node node_modules/.bin/eslint --cache 'packages/*/src/**/*.ts'
- node node_modules/.bin/tsc -p packages/core/tsconfig.json
- node packages/cli/build.js
- node node_modules/.bin/tsc -p packages/cli/tsconfig.json
- node node_modules/.bin/tsc -p ./
- node build.js
- node node_modules/.bin/mocha --exit
- node node_modules/.bin/c8 --exclude 'packages/core/**' --exclude-after-remap --reporter text-summary --reporter lcov node node_modules/.bin/mocha --require ./tests/require-hook.js --no-config --timeout 30000 tests/cli/test-cli-integration.js tests/cli/test-cli-units.js
- node tests/perf/run-performance-benchmark.js --json --iterations 1 --structs 4 --fields 3
- npm run perf:benchmark:json -- --iterations 1 --structs 4 --fields 3
- npm run perf:benchmark:ci -- --iterations 1 --structs 4 --fields 3
- node tests/perf/run-performance-benchmark.js --iterations 1 --structs 20 --fields 10