### PR TITLE
feat: refine include quick fixes and completions

### DIFF
--- a/packages/vscode/src/code-actions-provider.ts
+++ b/packages/vscode/src/code-actions-provider.ts
@@ -67,7 +67,7 @@ export class ThriftRefactorCodeActionProvider {
             // the diagnostics layer flagged as unknown (code 'type.unknown') and whose range
             // overlaps the requested range. This keeps the lightbulb in sync with the squiggly.
             const unknownTypes = this.collectUnknownTypeTargets(document, range, context);
-            if (unknownTypes.size === 0 || (typeof token !== 'undefined' && token.isCancellationRequested)) {
+            if (unknownTypes.length === 0 || (typeof token !== 'undefined' && token.isCancellationRequested)) {
                 return actions;
             }
 
@@ -79,27 +79,33 @@ export class ThriftRefactorCodeActionProvider {
 
             const includeSet = this.collectExistingIncludes(document);
             const insertLine = this.computeIncludeInsertLine(document);
-            for (const [typeName, diagnostic] of unknownTypes) {
+            for (const target of unknownTypes) {
                 if (typeof token !== 'undefined' && token.isCancellationRequested) {
                     break;
                 }
-                const definitions = workspaceTypeMap.get(typeName) ?? [];
+                const allDefinitions = workspaceTypeMap.get(target.name) ?? [];
+                const definitions = target.namespace === undefined
+                    ? allDefinitions
+                    : allDefinitions.filter(definition => definition.namespace === target.namespace);
+                if (target.namespace !== undefined && definitions.length !== 1) {
+                    continue;
+                }
                 for (const defUri of definitions) {
                     if (typeof token !== 'undefined' && token.isCancellationRequested) {
                         break;
                     }
-                    if (defUri.toString() === document.uri.toString()) {
+                    if (defUri.uri.toString() === document.uri.toString()) {
                         continue;
                     }
-                    const includePath = this.computeRelativeIncludePath(document.uri, defUri);
+                    const includePath = this.computeRelativeIncludePath(document.uri, defUri.uri);
                     if (includePath === undefined || includePath === '' || includeSet.has(includePath)) {
                         continue;
                     }
                     const fix = new vscode.CodeAction(`Insert include "${includePath}"`, vscode.CodeActionKind.QuickFix);
                     fix.edit = new vscode.WorkspaceEdit();
                     fix.edit.insert(document.uri, new vscode.Position(insertLine, 0), `include "${includePath}"\n`);
-                    fix.diagnostics = [diagnostic];
-                    fix.isPreferred = unknownTypes.size === 1 && definitions.length === 1;
+                    fix.diagnostics = [target.diagnostic];
+                    fix.isPreferred = unknownTypes.length === 1 && definitions.length === 1;
                     actions.push(fix);
                     includeSet.add(includePath);
                 }
@@ -124,6 +130,8 @@ export class ThriftRefactorCodeActionProvider {
     ]);
 
     private static readonly UNKNOWN_TYPE_CODES = UNKNOWN_TYPE_DIAGNOSTIC_CODES;
+
+    private static readonly TYPE_REFERENCE_PATTERN = /^([A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)$/;
 
     private addDuplicateFieldIdQuickFixes(
         document: vscode.TextDocument,
@@ -275,8 +283,9 @@ export class ThriftRefactorCodeActionProvider {
         document: vscode.TextDocument,
         range: vscode.Range | vscode.Selection,
         context: vscode.CodeActionContext
-    ): Map<string, vscode.Diagnostic> {
-        const targets = new Map<string, vscode.Diagnostic>();
+    ): Array<{name: string; namespace?: string; diagnostic: vscode.Diagnostic}> {
+        const targets: Array<{name: string; namespace?: string; diagnostic: vscode.Diagnostic}> = [];
+        const seen = new Set<string>();
         const diagnostics = context?.diagnostics ?? [];
         for (const diagnostic of diagnostics) {
             const code = this.getDiagnosticCode(diagnostic);
@@ -292,9 +301,11 @@ export class ThriftRefactorCodeActionProvider {
             } catch {
                 continue;
             }
-            for (const name of this.extractTypeNames(text)) {
-                if (!targets.has(name)) {
-                    targets.set(name, diagnostic);
+            for (const ref of this.extractTypeReferences(text)) {
+                const key = `${ref.namespace ?? ''}.${ref.name}`;
+                if (!seen.has(key)) {
+                    seen.add(key);
+                    targets.push({...ref, diagnostic});
                 }
             }
         }
@@ -306,8 +317,8 @@ export class ThriftRefactorCodeActionProvider {
      * 过滤掉容器关键字与基本类型，并跳过命名空间别名（紧跟 `.` 的标识符）。
      * 使用 angle-bracket 深度追踪替代正则处理嵌套泛型。
      */
-    private extractTypeNames(text: string): string[] {
-        const names: string[] = [];
+    private extractTypeReferences(text: string): Array<{name: string; namespace?: string}> {
+        const refs: Array<{name: string; namespace?: string}> = [];
         const seen = new Set<string>();
         const collectNames = (typeExpr: string): void => {
             const cleaned = typeExpr.trim();
@@ -319,18 +330,20 @@ export class ThriftRefactorCodeActionProvider {
                 }
                 return;
             }
-            // Plain type reference: extract the last dot-separated part
-            const parts = cleaned.split('.');
-            const name = parts[parts.length - 1].trim();
-            if (name.length > 0 &&
-                !ThriftRefactorCodeActionProvider.NON_TYPE_TOKENS.has(name) &&
-                !seen.has(name)) {
-                seen.add(name);
-                names.push(name);
+            const match = ThriftRefactorCodeActionProvider.TYPE_REFERENCE_PATTERN.exec(cleaned);
+            if (match === null) {
+                return;
+            }
+            const namespace = match[1]?.slice(0, -1);
+            const name = match[2];
+            const key = `${namespace ?? ''}.${name}`;
+            if (!ThriftRefactorCodeActionProvider.NON_TYPE_TOKENS.has(name) && !seen.has(key)) {
+                seen.add(key);
+                refs.push(namespace === undefined ? {name} : {name, namespace});
             }
         };
         collectNames(text);
-        return names;
+        return refs;
     }
 
     /**
@@ -393,15 +406,15 @@ export class ThriftRefactorCodeActionProvider {
      */
     private async buildWorkspaceTypeMap(
         token?: vscode.CancellationToken
-    ): Promise<Map<string, vscode.Uri[]>> {
-        const typeMap = new Map<string, vscode.Uri[]>();
+    ): Promise<Map<string, Array<{uri: vscode.Uri; namespace?: string}>>> {
+        const typeMap = new Map<string, Array<{uri: vscode.Uri; namespace?: string}>>();
         if (this.workspaceIndex !== undefined) {
             for (const symbol of this.workspaceIndex.getAllSymbols()) {
                 if (typeof token !== 'undefined' && token.isCancellationRequested) {
                     break;
                 }
                 const uris = typeMap.get(symbol.name) ?? [];
-                uris.push(symbol.uri);
+                uris.push({uri: symbol.uri, namespace: symbol.namespace});
                 typeMap.set(symbol.name, uris);
             }
             return typeMap;
@@ -416,6 +429,10 @@ export class ThriftRefactorCodeActionProvider {
             try {
                 const text = await readThriftFile(file);
                 const ast = ThriftParser.parseContentWithCache(file.toString(), text);
+                const namespaceNode = ast.body.find((node): node is nodes.Namespace =>
+                    node.type === nodes.ThriftNodeType.Namespace
+                );
+                const namespace = namespaceNode?.namespace;
                 for (const node of collectTopLevelTypes(ast)) {
                     if (node.name === undefined || node.name === '') { continue; }
                     if (node.type === nodes.ThriftNodeType.Struct ||
@@ -429,7 +446,7 @@ export class ThriftRefactorCodeActionProvider {
                             uris = [];
                             typeMap.set(node.name, uris);
                         }
-                        uris.push(file);
+                        uris.push({uri: file, namespace});
                     }
                 }
             } catch {

--- a/packages/vscode/src/completion/items.ts
+++ b/packages/vscode/src/completion/items.ts
@@ -49,17 +49,34 @@ export const ANNOTATION_VALUES = [
  * @param userTypes 用户定义的类型列表
  */
 export function addTypeCompletions(completions: vscode.CompletionItem[], userTypes: string[]) {
+    const existingLabels = new Set(completions.map(item => getCompletionLabel(item)));
     PRIMITIVES.forEach((p) => {
+        if (existingLabels.has(p)) {
+            return;
+        }
         completions.push(new vscode.CompletionItem(p, vscode.CompletionItemKind.Keyword));
+        existingLabels.add(p);
     });
     CONTAINERS.forEach((c) => {
+        if (existingLabels.has(c)) {
+            return;
+        }
         const item = new vscode.CompletionItem(c, vscode.CompletionItemKind.Keyword);
         item.insertText = new vscode.SnippetString(`${c}<\${1:T}>`);
         completions.push(item);
+        existingLabels.add(c);
     });
     userTypes.forEach((t) => {
+        if (existingLabels.has(t)) {
+            return;
+        }
         completions.push(new vscode.CompletionItem(t, vscode.CompletionItemKind.Class));
+        existingLabels.add(t);
     });
+}
+
+function getCompletionLabel(item: vscode.CompletionItem): string {
+    return typeof item.label === 'string' ? item.label : item.label.label;
 }
 
 /**

--- a/packages/vscode/src/completion/provider.ts
+++ b/packages/vscode/src/completion/provider.ts
@@ -160,14 +160,14 @@ export class ThriftCompletionProvider implements vscode.CompletionItemProvider {
         if (this.workspaceIndex === undefined) {
             return [];
         }
-        const names: string[] = [];
+        const names = new Set<string>();
         for (const symbol of this.workspaceIndex.getAllSymbols()) {
-            names.push(symbol.name);
+            names.add(symbol.name);
             if (symbol.namespace !== undefined && symbol.namespace !== '') {
-                names.push(`${symbol.namespace}.${symbol.name}`);
+                names.add(`${symbol.namespace}.${symbol.name}`);
             }
         }
-        return names;
+        return [...names].sort((a, b) => a.localeCompare(b));
     }
 }
 

--- a/tests/src/code-actions-provider/test-workspace-index-integration.js
+++ b/tests/src/code-actions-provider/test-workspace-index-integration.js
@@ -32,4 +32,83 @@ describe('ThriftRefactorCodeActionProvider WorkspaceIndex integration', function
         const includeAction = actions.find(action => action.title === 'Insert include "models/user.thrift"');
         assert.ok(includeAction);
     });
+
+    it('suggests a namespace alias include only when the namespace match is unique', async function () {
+        const targetUri = vscode.Uri.file('/workspace/models/foo.thrift');
+        const provider = new ThriftRefactorCodeActionProvider({
+            workspaceIndex: {
+                getAllSymbols: () => [
+                    {
+                        name: 'Bar',
+                        namespace: 'foo',
+                        kind: nodes.ThriftNodeType.Struct,
+                        uri: targetUri,
+                        range: new vscode.Range(0, 0, 0, 10),
+                        nameRange: new vscode.Range(0, 7, 0, 10)
+                    },
+                    {
+                        name: 'Bar',
+                        namespace: 'other',
+                        kind: nodes.ThriftNodeType.Struct,
+                        uri: vscode.Uri.file('/workspace/models/other.thrift'),
+                        range: new vscode.Range(0, 0, 0, 10),
+                        nameRange: new vscode.Range(0, 7, 0, 10)
+                    }
+                ]
+            }
+        });
+        const document = vscode.createTextDocument('struct Local {\n  1: foo.Bar item\n}\n', vscode.Uri.file('/workspace/main.thrift'));
+        document.languageId = 'thrift';
+        document.version = 1;
+        const diagnosticRange = new vscode.Range(1, 5, 1, 12);
+
+        const actions = await provider.provideCodeActions(
+            document,
+            diagnosticRange,
+            {diagnostics: [{code: 'type.unknown', range: diagnosticRange}]},
+            {isCancellationRequested: false}
+        );
+
+        const includeActions = actions.filter(action => action.title.startsWith('Insert include'));
+        assert.deepStrictEqual(includeActions.map(action => action.title), ['Insert include "models/foo.thrift"']);
+        assert.strictEqual(includeActions[0].isPreferred, true);
+    });
+
+    it('does not suggest a namespace alias include when multiple files match the alias and type', async function () {
+        const provider = new ThriftRefactorCodeActionProvider({
+            workspaceIndex: {
+                getAllSymbols: () => [
+                    {
+                        name: 'Bar',
+                        namespace: 'foo',
+                        kind: nodes.ThriftNodeType.Struct,
+                        uri: vscode.Uri.file('/workspace/models/foo-a.thrift'),
+                        range: new vscode.Range(0, 0, 0, 10),
+                        nameRange: new vscode.Range(0, 7, 0, 10)
+                    },
+                    {
+                        name: 'Bar',
+                        namespace: 'foo',
+                        kind: nodes.ThriftNodeType.Struct,
+                        uri: vscode.Uri.file('/workspace/models/foo-b.thrift'),
+                        range: new vscode.Range(0, 0, 0, 10),
+                        nameRange: new vscode.Range(0, 7, 0, 10)
+                    }
+                ]
+            }
+        });
+        const document = vscode.createTextDocument('struct Local {\n  1: foo.Bar item\n}\n', vscode.Uri.file('/workspace/main.thrift'));
+        document.languageId = 'thrift';
+        document.version = 1;
+        const diagnosticRange = new vscode.Range(1, 5, 1, 12);
+
+        const actions = await provider.provideCodeActions(
+            document,
+            diagnosticRange,
+            {diagnostics: [{code: 'type.unknown', range: diagnosticRange}]},
+            {isCancellationRequested: false}
+        );
+
+        assert.strictEqual(actions.some(action => action.title.startsWith('Insert include')), false);
+    });
 });

--- a/tests/src/completion-provider/test-completion-provider-editor-ux.js
+++ b/tests/src/completion-provider/test-completion-provider-editor-ux.js
@@ -41,6 +41,37 @@ describe('completion provider editor UX', function () {
         assert.ok(labels.includes('shared.RemoteUser'));
     });
 
+    it('deduplicates workspace type completions by label', async function () {
+        const provider = new ThriftCompletionProvider({
+            workspaceIndex: {
+                getAllSymbols: () => [
+                    {
+                        name: 'RemoteUser',
+                        namespace: 'shared',
+                        uri: vscode.Uri.file('/tmp/shared-a.thrift')
+                    },
+                    {
+                        name: 'RemoteUser',
+                        namespace: 'shared',
+                        uri: vscode.Uri.file('/tmp/shared-b.thrift')
+                    }
+                ]
+            }
+        });
+        const document = createDocument('struct Local {\n  1: optional \n}\n');
+
+        const items = await provider.provideCompletionItems(
+            document,
+            new vscode.Position(1, '  1: optional '.length),
+            {isCancellationRequested: false},
+            {}
+        );
+        const labels = items.map(item => item.label);
+
+        assert.strictEqual(labels.filter(label => label === 'RemoteUser').length, 1);
+        assert.strictEqual(labels.filter(label => label === 'shared.RemoteUser').length, 1);
+    });
+
     it('suggests annotation keys and values inside annotation context', async function () {
         const provider = new ThriftCompletionProvider();
         const keyDocument = createDocument('struct Local {\n  1: string name (\n}\n');


### PR DESCRIPTION
## Summary
- add namespace-aware include quick fix behavior for unknown aliases with unique workspace matches
- suppress include quick fixes when alias/type resolution is ambiguous
- deduplicate and sort workspace type completions by label

## Test Plan
- npm run lint:fix
- npm run lint
- npm run build (blocked by local pnpm shim: missing pnpm v10.25.0 binary under .pnpm-store)
- node node_modules/.bin/eslint --cache 'packages/*/src/**/*.ts' --fix
- node node_modules/.bin/eslint --cache 'packages/*/src/**/*.ts'
- node node_modules/.bin/tsc -p packages/core/tsconfig.json
- node packages/cli/build.js
- node node_modules/.bin/tsc -p packages/cli/tsconfig.json
- node node_modules/.bin/tsc -p ./
- node build.js
- node node_modules/.bin/mocha --exit
- node node_modules/.bin/c8 --exclude 'packages/core/**' --exclude-after-remap --reporter text-summary --reporter lcov node node_modules/.bin/mocha --require ./tests/require-hook.js --no-config --timeout 30000 tests/cli/test-cli-integration.js tests/cli/test-cli-units.js