### PR TITLE
refactor: split parser declaration helpers

### DIFF
--- a/packages/core/src/ast/parser-const.ts
+++ b/packages/core/src/ast/parser-const.ts
@@ -1,0 +1,89 @@
+import * as nodes from './nodes.types';
+import {QuoteTracker} from '../utils/quote-tracker';
+import {buildConstValueRange, findTypeRangeInLine, findWordRangeInLine} from './parser-helpers';
+import {Range} from '../types';
+
+export function parseConstDeclarationNode(
+    parent: nodes.ThriftNode,
+    lines: string[],
+    startLine: number,
+    valueType: string,
+    name: string
+): {node: nodes.Const; endLine: number} {
+    const line = lines[startLine] ?? '';
+    const keywordIndex = line.indexOf('const');
+    const searchStart = keywordIndex >= 0 ? keywordIndex + 'const'.length : 0;
+    let endLine = startLine;
+    let depthBrace = 0;
+    let depthBracket = 0;
+    let depthParen = 0;
+    let seenEquals = false;
+    let eqLine = -1;
+    let eqChar = -1;
+    const quoteTracker = new QuoteTracker();
+
+    while (endLine < lines.length) {
+        const currentLine = lines[endLine] ?? '';
+        for (let index = 0; index < currentLine.length; index++) {
+            const char = currentLine[index];
+            if (quoteTracker.inside()) {
+                quoteTracker.feed(char);
+                continue;
+            }
+            if (char === '\'' || char === '"') {
+                quoteTracker.feed(char);
+                continue;
+            }
+            if (char === '=' && !seenEquals) {
+                seenEquals = true;
+                if (eqLine === -1) {
+                    eqLine = endLine;
+                    eqChar = index;
+                }
+                continue;
+            }
+            if (!seenEquals) {
+                continue;
+            }
+            if (char === '{') {
+                depthBrace++;
+            }
+            if (char === '}') {
+                depthBrace = Math.max(0, depthBrace - 1);
+            }
+            if (char === '[') {
+                depthBracket++;
+            }
+            if (char === ']') {
+                depthBracket = Math.max(0, depthBracket - 1);
+            }
+            if (char === '(') {
+                depthParen++;
+            }
+            if (char === ')') {
+                depthParen = Math.max(0, depthParen - 1);
+            }
+        }
+
+        if (seenEquals && depthBrace === 0 && depthBracket === 0 && depthParen === 0) {
+            break;
+        }
+        endLine++;
+    }
+
+    const valueRangeInfo = buildConstValueRange(lines, startLine, endLine, eqLine, eqChar);
+    return {
+        node: {
+            type: nodes.ThriftNodeType.Const,
+            range: new Range(startLine, 0, endLine, (lines[endLine] ?? '').length),
+            nameRange: findWordRangeInLine(line, startLine, name, searchStart),
+            parent,
+            valueType,
+            valueTypeRange: findTypeRangeInLine(line, startLine, valueType, searchStart),
+            name,
+            value: valueRangeInfo.value,
+            valueRange: valueRangeInfo.range
+        },
+        endLine
+    };
+}

--- a/packages/core/src/ast/parser-functions.ts
+++ b/packages/core/src/ast/parser-functions.ts
@@ -1,0 +1,194 @@
+import {Range} from '../types';
+import * as nodes from './nodes.types';
+import {
+    findThrowsStartInRange,
+    parseFieldList,
+    readParenthesizedText
+} from './parser-helpers';
+import {findSymbolIndex} from './token-utils';
+import {Token} from './tokenizer';
+
+export interface ParsedServiceFunction {
+    name: string;
+    returnType: string;
+    nameRange: Range | undefined;
+    returnTypeRange: Range | undefined;
+    oneway: boolean;
+    isStream: boolean;
+    isSink: boolean;
+    funcStartLine: number;
+    funcStartChar: number;
+    funcEndLine: number;
+    funcEndChar: number;
+}
+
+export interface ParsedThrows {
+    fields: nodes.Field[];
+    endLine: number;
+    endChar: number;
+}
+
+export function parsePerforms(
+    parent: nodes.ThriftNode,
+    line: string,
+    cleanLine: string,
+    tokens: Token[],
+    lineNumber: number
+): nodes.Performs | null {
+    const trimmed = cleanLine.trim();
+    if (!trimmed || tokens.length === 0) {
+        return null;
+    }
+    if (tokens[0].type !== 'identifier' || tokens[0].value !== 'performs') {
+        return null;
+    }
+    const nameToken = tokens[1];
+    if (nameToken === undefined || nameToken.type !== 'identifier') {
+        return null;
+    }
+    const nameRange = new Range(lineNumber, nameToken.start, lineNumber, nameToken.end);
+    return {
+        type: nodes.ThriftNodeType.Performs,
+        range: new Range(lineNumber, 0, lineNumber, line.length),
+        nameRange,
+        parent,
+        name: nameToken.value,
+        interactionName: nameToken.value,
+        interactionNameRange: nameRange
+    };
+}
+
+export function parseServiceFunctionLine(
+    line: string,
+    cleanLine: string,
+    tokens: Token[],
+    lineNumber: number
+): ParsedServiceFunction | null {
+    const trimmed = cleanLine.trim();
+    if (!trimmed || tokens.length === 0) {
+        return null;
+    }
+    const parenIndex = findSymbolIndex(tokens, '(');
+    if (parenIndex === -1) {
+        return null;
+    }
+    let nameTokenIndex = -1;
+    for (let index = parenIndex - 1; index >= 0; index--) {
+        if (tokens[index].type === 'identifier') {
+            nameTokenIndex = index;
+            break;
+        }
+    }
+    if (nameTokenIndex === -1) {
+        return null;
+    }
+    const oneway = tokens[0].type === 'identifier' && tokens[0].value === 'oneway';
+    let returnTypeStartIndex = oneway ? 1 : 0;
+    let isStream = false;
+    let isSink = false;
+    if (returnTypeStartIndex < tokens.length && tokens[returnTypeStartIndex].type === 'identifier') {
+        if (tokens[returnTypeStartIndex].value === 'stream') {
+            isStream = true;
+            returnTypeStartIndex += 1;
+        } else if (tokens[returnTypeStartIndex].value === 'sink') {
+            isSink = true;
+            returnTypeStartIndex += 1;
+        }
+    }
+    const returnTypeStartToken = tokens[returnTypeStartIndex];
+    if (returnTypeStartToken === undefined || returnTypeStartIndex >= nameTokenIndex) {
+        return null;
+    }
+    const nameToken = tokens[nameTokenIndex];
+    const typeStart = isStream || isSink ? returnTypeStartIndex - 1 : returnTypeStartIndex;
+    const returnType = cleanLine.slice(tokens[typeStart].start, nameToken.start).trim();
+    if (!returnType) {
+        return null;
+    }
+    return {
+        name: nameToken.value,
+        returnType,
+        nameRange: new Range(lineNumber, nameToken.start, lineNumber, nameToken.end),
+        returnTypeRange: new Range(lineNumber, tokens[typeStart].start, lineNumber, nameToken.start),
+        oneway,
+        isStream,
+        isSink,
+        funcStartLine: lineNumber,
+        funcStartChar: tokens[typeStart].start,
+        funcEndLine: lineNumber,
+        funcEndChar: line.length
+    };
+}
+
+export function findFunctionEnd(
+    lines: string[],
+    startLine: number,
+    startChar: number,
+    initialParenCount: number
+): {endLine: number; endChar: number} | null {
+    let parenCount = initialParenCount;
+    for (let lineNumber = startLine; lineNumber < lines.length; lineNumber++) {
+        const text = lines[lineNumber] ?? '';
+        const colStart = lineNumber === startLine ? startChar : 0;
+        for (let index = colStart; index < text.length; index++) {
+            if (text[index] === '(') {
+                parenCount++;
+            } else if (text[index] === ')') {
+                parenCount--;
+                if (parenCount === 0) {
+                    const endChar = skipThrowsBlock(text, index + 1);
+                    if (endChar < text.length && (text[endChar] === ',' || text[endChar] === ';' || text[endChar] === '{')) {
+                        return {endLine: lineNumber, endChar: endChar + 1};
+                    }
+                }
+            }
+        }
+    }
+    return null;
+}
+
+export function parseFunctionThrows(
+    lines: string[],
+    argsEndLine: number,
+    argsEndChar: number,
+    funcEndLine: number,
+    funcEndChar: number
+): ParsedThrows {
+    const fields: nodes.Field[] = [];
+    let resultEndLine = funcEndLine;
+    let resultEndChar = funcEndChar;
+
+    const throwsStart = findThrowsStartInRange(lines, argsEndLine, argsEndChar, funcEndLine, funcEndChar);
+    if (throwsStart) {
+        const throwsResult = readParenthesizedText(lines, throwsStart.line, throwsStart.char + 1);
+        if (throwsResult) {
+            fields.push(...parseFieldList(throwsResult.text, throwsStart.line, throwsStart.char + 1));
+            resultEndLine = throwsResult.endLine;
+            resultEndChar = throwsResult.endChar;
+        }
+    }
+    return {fields, endLine: resultEndLine, endChar: resultEndChar};
+}
+
+function skipThrowsBlock(line: string, start: number): number {
+    if (line.substring(start, start + 6) !== 'throws') {
+        return start;
+    }
+    let throwsParenCount = 0;
+    let index = start + 6;
+    for (; index < line.length; index++) {
+        if (line[index] === '(') {
+            throwsParenCount++;
+        } else if (line[index] === ')') {
+            throwsParenCount--;
+            if (throwsParenCount === 0) {
+                index++;
+                break;
+            }
+        }
+    }
+    while (index < line.length && /\s/.test(line[index] ?? '')) {
+        index++;
+    }
+    return index;
+}

--- a/packages/core/src/ast/parser-members.ts
+++ b/packages/core/src/ast/parser-members.ts
@@ -1,0 +1,261 @@
+import {Range} from '../types';
+import * as nodes from './nodes.types';
+import {createField} from './factory';
+import {findDefaultValueRange, findInitializerRange, stripTrailingAnnotation} from './parser-helpers';
+import {findSymbolIndex, findSymbolIndexFrom} from './token-utils';
+import {Token} from './tokenizer';
+
+export function computeStructFieldEndLine(lines: string[], startLine: number): number {
+    let depthAngle = 0;
+    let depthBracket = 0;
+    let depthBrace = 0;
+    let depthParen = 0;
+    let inBlockComment = false;
+
+    for (let lineIndex = startLine; lineIndex < lines.length; lineIndex++) {
+        const stripped = stripCommentsAndStrings(lines[lineIndex] ?? '', inBlockComment);
+        inBlockComment = stripped.endsInBlockComment;
+        const text = stripped.text;
+        for (let charIndex = 0; charIndex < text.length; charIndex++) {
+            const char = text[charIndex];
+            if (char === '<') { depthAngle++; continue; }
+            if (char === '>') { depthAngle = Math.max(0, depthAngle - 1); continue; }
+            if (char === '[') { depthBracket++; continue; }
+            if (char === ']') { depthBracket = Math.max(0, depthBracket - 1); continue; }
+            if (char === '{') { depthBrace++; continue; }
+            if (char === '}') {
+                if (depthBrace === 0) {
+                    return Math.max(startLine, lineIndex - 1);
+                }
+                depthBrace--;
+                continue;
+            }
+            if (char === '(') { depthParen++; continue; }
+            if (char === ')') { depthParen = Math.max(0, depthParen - 1); continue; }
+            if (depthAngle === 0 && depthBracket === 0 && depthBrace === 0 && depthParen === 0
+                && (char === ',' || char === ';')) {
+                return lineIndex;
+            }
+        }
+        if (!inBlockComment) {
+            const next = findNextNonEmptyLineRaw(lines, lineIndex + 1);
+            if (next === -1) { return lineIndex; }
+            const nextStripped = stripCommentsAndStrings(lines[next] ?? '', false).text.trim();
+            if (/^\d+\s*:/.test(nextStripped)) {
+                return lineIndex;
+            }
+            if (depthAngle === 0 && depthBracket === 0 && depthBrace === 0 && depthParen === 0
+                && nextStripped.startsWith('}')) {
+                return lineIndex;
+            }
+        }
+    }
+    return lines.length - 1;
+}
+
+export function parseStructFieldLine(
+    parent: nodes.Struct,
+    line: string,
+    cleanLine: string,
+    tokens: Token[],
+    lineNumber: number
+): nodes.Field | null {
+    const trimmed = cleanLine.trim();
+    if (!trimmed || tokens.length === 0) {
+        return null;
+    }
+    const idIndex = tokens.findIndex(token => token.type === 'number');
+    if (idIndex === -1) {
+        return null;
+    }
+    const colonIndex = findSymbolIndexFrom(tokens, ':', idIndex + 1);
+    if (colonIndex === -1) {
+        return null;
+    }
+    let cursor = colonIndex + 1;
+    let requiredness: 'required' | 'optional' | undefined;
+    if (tokens[cursor]?.type === 'identifier' &&
+        (tokens[cursor].value === 'required' || tokens[cursor].value === 'optional')) {
+        requiredness = tokens[cursor].value as 'required' | 'optional';
+        cursor += 1;
+    }
+    const typeStartToken = tokens[cursor];
+    if (typeStartToken === undefined) {
+        return null;
+    }
+    let nameTokenIndex = -1;
+    let angleDepth = 0;
+    for (let index = cursor; index < tokens.length; index++) {
+        const token = tokens[index];
+        if (token.type === 'symbol') {
+            if (token.value === '<') {
+                angleDepth += 1;
+            } else if (token.value === '>') {
+                angleDepth = Math.max(0, angleDepth - 1);
+            }
+            if (angleDepth === 0 && (token.value === '(' || token.value === '=' || token.value === ',' || token.value === ';')) {
+                break;
+            }
+            continue;
+        }
+        if (token.type === 'identifier') {
+            nameTokenIndex = index;
+        }
+    }
+    if (nameTokenIndex === -1) {
+        return null;
+    }
+    const nameToken = tokens[nameTokenIndex];
+    const fieldType = cleanLine.slice(typeStartToken.start, nameToken.start).trim();
+    if (!fieldType) {
+        return null;
+    }
+    const valueTarget = stripTrailingAnnotation(cleanLine.replace(/[,;]\s*$/, ''));
+    const defaultInfo = findDefaultValueRange(valueTarget);
+    return createField({
+        range: new Range(lineNumber, 0, lineNumber, line.length),
+        nameRange: new Range(lineNumber, nameToken.start, lineNumber, nameToken.end),
+        typeRange: new Range(lineNumber, typeStartToken.start, lineNumber, nameToken.start),
+        parent,
+        id: parseInt(tokens[idIndex].value, 10),
+        requiredness,
+        fieldType,
+        name: nameToken.value,
+        defaultValue: defaultInfo?.value,
+        defaultValueRange: defaultInfo !== null
+            ? new Range(lineNumber, defaultInfo.start, lineNumber, defaultInfo.end)
+            : undefined
+    });
+}
+
+export function parseEnumMemberLine(
+    parent: nodes.Enum,
+    line: string,
+    cleanLine: string,
+    tokens: Token[],
+    lineNumber: number
+): nodes.EnumMember | null {
+    const trimmed = cleanLine.trim();
+    if (!trimmed || tokens.length === 0) {
+        return null;
+    }
+    const nameToken = tokens.find(token => token.type === 'identifier');
+    if (!nameToken) {
+        return null;
+    }
+    const equalsIndex = findSymbolIndex(tokens, '=');
+    let initializer: string | undefined;
+    let initializerRange: Range | undefined;
+    if (equalsIndex !== -1) {
+        const initializerBounds = readInitializerBounds(tokens, equalsIndex);
+        if (initializerBounds !== null) {
+            const rawInitializer = cleanLine.slice(initializerBounds.start, initializerBounds.end).trim();
+            const trimmedInitializer = stripTrailingAnnotation(rawInitializer.replace(/[,;]\s*$/, '')).trim();
+            initializer = trimmedInitializer || undefined;
+            if (initializer !== undefined && initializer !== '') {
+                initializerRange = new Range(lineNumber, initializerBounds.start, lineNumber, initializerBounds.end);
+            }
+        }
+    }
+    initializerRange ??= findInitializerRange(cleanLine, cleanLine, initializer, lineNumber);
+    return {
+        type: nodes.ThriftNodeType.EnumMember,
+        range: new Range(lineNumber, 0, lineNumber, line.length),
+        nameRange: new Range(lineNumber, nameToken.start, lineNumber, nameToken.end),
+        parent,
+        name: nameToken.value,
+        initializer,
+        initializerRange
+    };
+}
+
+function readInitializerBounds(tokens: Token[], equalsIndex: number): {start: number; end: number} | null {
+    let startOffset: number | null = null;
+    let endOffset: number | null = null;
+    let angleDepth = 0;
+    let bracketDepth = 0;
+    let braceDepth = 0;
+    let parenDepth = 0;
+    for (let index = equalsIndex + 1; index < tokens.length; index++) {
+        const token = tokens[index];
+        if (token.type === 'symbol') {
+            if (token.value === '<') {
+                angleDepth += 1;
+            } else if (token.value === '>') {
+                angleDepth = Math.max(0, angleDepth - 1);
+            } else if (token.value === '[') {
+                bracketDepth += 1;
+            } else if (token.value === ']') {
+                bracketDepth = Math.max(0, bracketDepth - 1);
+            } else if (token.value === '{') {
+                braceDepth += 1;
+            } else if (token.value === '}') {
+                braceDepth = Math.max(0, braceDepth - 1);
+            } else if (token.value === '(') {
+                parenDepth += 1;
+            } else if (token.value === ')') {
+                parenDepth = Math.max(0, parenDepth - 1);
+            }
+            if (angleDepth === 0 && bracketDepth === 0 && braceDepth === 0 && parenDepth === 0 &&
+                (token.value === ',' || token.value === ';' || token.value === '(')) {
+                break;
+            }
+        }
+        startOffset ??= token.start;
+        endOffset = token.end;
+    }
+    return startOffset !== null && endOffset !== null ? {start: startOffset, end: endOffset} : null;
+}
+
+function findNextNonEmptyLineRaw(lines: string[], startIndex: number): number {
+    for (let index = startIndex; index < lines.length; index++) {
+        if (stripCommentsAndStrings(lines[index] ?? '', false).text.trim()) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+function stripCommentsAndStrings(line: string, inBlockComment: boolean): {text: string; endsInBlockComment: boolean} {
+    let output = '';
+    let index = 0;
+    let block = inBlockComment;
+    let escaped = false;
+    while (index < line.length) {
+        if (block) {
+            const close = line.indexOf('*/', index);
+            if (close === -1) {
+                return {text: output, endsInBlockComment: true};
+            }
+            index = close + 2;
+            block = false;
+            continue;
+        }
+        const char = line[index];
+        const next = index + 1 < line.length ? line[index + 1] : '';
+        if (char === '/' && next === '*') {
+            block = true;
+            index += 2;
+            continue;
+        }
+        if ((char === '/' && next === '/') || char === '#') {
+            break;
+        }
+        if (char === '"' || char === '\'') {
+            const quote = char;
+            index++;
+            escaped = false;
+            while (index < line.length) {
+                const current = line[index];
+                if (escaped) { escaped = false; index++; continue; }
+                if (current === '\\') { escaped = true; index++; continue; }
+                if (current === quote) { index++; break; }
+                index++;
+            }
+            continue;
+        }
+        output += char;
+        index++;
+    }
+    return {text: output, endsInBlockComment: block};
+}

--- a/packages/core/src/ast/parser.ts
+++ b/packages/core/src/ast/parser.ts
@@ -10,25 +10,16 @@ import {
     setCachedAstRange
 } from './cache';
 import {createLineRange, LineRange} from '../utils/line-range';
-import {QuoteTracker} from '../utils/quote-tracker';
-import {createField, createDocument, createStructBlock, createEnumBlock, createServiceBlock, createInteractionBlock} from './factory';
+import {createDocument, createStructBlock, createEnumBlock, createServiceBlock, createInteractionBlock} from './factory';
 import {isExpired, isFresh} from '../utils/cache-expiry';
 import {
-    buildConstValueRange,
-    findDefaultValueRange,
-    findInitializerRange,
-    findThrowsStartInRange,
-    findTypeRangeInLine,
     findWordRangeInLine,
     parseFieldList,
-    readParenthesizedText,
-    stripTrailingAnnotation
+    readParenthesizedText
 } from './parser-helpers';
 import {
     filterMeaningfulTokens,
-    findFirstIdentifier,
-    findSymbolIndex,
-    findSymbolIndexFrom
+    findFirstIdentifier
 } from './token-utils';
 import {ThriftTokenizer, Token, tokenizeLine} from './tokenizer';
 import {
@@ -38,6 +29,15 @@ import {
     readConstDeclarationHeader,
     readServiceHeader
 } from './parser-top-level';
+import {parseConstDeclarationNode} from './parser-const';
+import {computeStructFieldEndLine, parseEnumMemberLine, parseStructFieldLine} from './parser-members';
+import {
+    findFunctionEnd,
+    parseFunctionThrows,
+    parsePerforms,
+    parseServiceFunctionLine,
+    ParsedServiceFunction
+} from './parser-functions';
 
 export interface ParseRegion {
     startLine: number;
@@ -414,9 +414,9 @@ export class ThriftParser {
             }
 
             const startLine = this.currentLine;
-            const field = this.parseStructFieldLine(parent, line, scan.stripped, scan.tokens);
+            const field = parseStructFieldLine(parent, line, scan.stripped, scan.tokens, this.currentLine);
             if (field) {
-                const endLine = this.computeStructFieldEndLine(startLine);
+                const endLine = computeStructFieldEndLine(this.lines, startLine);
                 if (endLine > startLine) {
                     field.range = this.createRange(
                         startLine,
@@ -433,206 +433,6 @@ export class ThriftParser {
             }
         }
         return this.currentLine;
-    }
-
-    /**
-     * 给定字段起始行，计算其真实结束行（考虑跨行 default value 与尾部注解）。
-     * 字符级扫描 `[]`/`{}`/`()` 嵌套；遇到 struct body 自身的 `}`（所有 brace 深度归零时出现的 `}`）则停止。
-     * 内联处理字符串字面量与单行/块注释，避免依赖 tokenizer 的跨行 state。
-     */
-    private computeStructFieldEndLine(startLine: number): number {
-        let depthAngle = 0;
-        let depthBracket = 0;
-        let depthBrace = 0;
-        let depthParen = 0;
-        let inBlockComment = false;
-
-        for (let li = startLine; li < this.lines.length; li++) {
-            const stripped = this.stripCommentsAndStrings(this.lines[li], inBlockComment);
-            inBlockComment = stripped.endsInBlockComment;
-            const text = stripped.text;
-            for (let i = 0; i < text.length; i++) {
-                const ch = text[i];
-                if (ch === '<') { depthAngle++; continue; }
-                if (ch === '>') { depthAngle = Math.max(0, depthAngle - 1); continue; }
-                if (ch === '[') { depthBracket++; continue; }
-                if (ch === ']') { depthBracket = Math.max(0, depthBracket - 1); continue; }
-                if (ch === '{') { depthBrace++; continue; }
-                if (ch === '}') {
-                    if (depthBrace === 0) {
-                        return Math.max(startLine, li - 1);
-                    }
-                    depthBrace--;
-                    continue;
-                }
-                if (ch === '(') { depthParen++; continue; }
-                if (ch === ')') { depthParen = Math.max(0, depthParen - 1); continue; }
-                if (depthAngle === 0 && depthBracket === 0 && depthBrace === 0 && depthParen === 0
-                    && (ch === ',' || ch === ';')) {
-                    return li;
-                }
-            }
-            if (!inBlockComment) {
-                const next = this.findNextNonEmptyLineRaw(li + 1);
-                if (next === -1) { return li; }
-                const nextStripped = this.stripCommentsAndStrings(this.lines[next], false).text.trim();
-                // Recovery: if the next line opens a new field, treat the current field as ended
-                // here even when brackets are still unbalanced (malformed source).
-                if (/^\d+\s*:/.test(nextStripped)) {
-                    return li;
-                }
-                if (depthAngle === 0 && depthBracket === 0 && depthBrace === 0 && depthParen === 0
-                    && nextStripped.startsWith('}')) {
-                    return li;
-                }
-            }
-        }
-        return this.lines.length - 1;
-    }
-
-    private findNextNonEmptyLineRaw(startIdx: number): number {
-        for (let i = startIdx; i < this.lines.length; i++) {
-            if (this.stripCommentsAndStrings(this.lines[i], false).text.trim()) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    /**
-     * 去除字符串字面量内容与注释，仅保留结构性字符（括号、逗号、分号等）。
-     * 注意：字符串内容被**移除**（不保留占位符），因此返回的 text 不可用于
-     * 列位置计算——仅适用于结构性扫描。
-     * 不修改 this.tokenizer 的跨行 state。
-     */
-    private stripCommentsAndStrings(line: string, inBlockComment: boolean): {text: string; endsInBlockComment: boolean} {
-        let out = '';
-        let i = 0;
-        let block = inBlockComment;
-        let escaped = false;
-        while (i < line.length) {
-            if (block) {
-                const close = line.indexOf('*/', i);
-                if (close === -1) {
-                    return {text: out, endsInBlockComment: true};
-                }
-                i = close + 2;
-                block = false;
-                continue;
-            }
-            const ch = line[i];
-            const next = i + 1 < line.length ? line[i + 1] : '';
-            if (ch === '/' && next === '*') {
-                block = true;
-                i += 2;
-                continue;
-            }
-            if ((ch === '/' && next === '/') || ch === '#') {
-                break;
-            }
-            if (ch === '"' || ch === '\'') {
-                const quote = ch;
-                i++;
-                escaped = false;
-                while (i < line.length) {
-                    const c = line[i];
-                    if (escaped) { escaped = false; i++; continue; }
-                    if (c === '\\') { escaped = true; i++; continue; }
-                    if (c === quote) { i++; break; }
-                    i++;
-                }
-                continue;
-            }
-            out += ch;
-            i++;
-        }
-        return {text: out, endsInBlockComment: block};
-    }
-
-    private parseStructFieldLine(parent: nodes.Struct, line: string, cleanLine: string, tokens: Token[]): nodes.Field | null {
-        const trimmed = cleanLine.trim();
-        if (!trimmed) {
-            return null;
-        }
-        if (tokens.length === 0) {
-            return null;
-        }
-        const idIndex = tokens.findIndex(token => token.type === 'number');
-        if (idIndex === -1) {
-            return null;
-        }
-        const colonIndex = findSymbolIndexFrom(tokens, ':', idIndex + 1);
-        if (colonIndex === -1) {
-            return null;
-        }
-        let cursor = colonIndex + 1;
-        let requiredness: 'required' | 'optional' | undefined;
-        if (tokens[cursor]?.type === 'identifier' &&
-            (tokens[cursor].value === 'required' || tokens[cursor].value === 'optional')) {
-            requiredness = tokens[cursor].value as 'required' | 'optional';
-            cursor += 1;
-        }
-        const typeStartToken = tokens[cursor];
-        if (typeStartToken === undefined) {
-            return null;
-        }
-        let nameTokenIndex = -1;
-        let angleDepth = 0;
-        for (let i = cursor; i < tokens.length; i++) {
-            const token = tokens[i];
-            if (token.type === 'symbol') {
-                if (token.value === '<') {
-                    angleDepth += 1;
-                } else if (token.value === '>') {
-                    angleDepth = Math.max(0, angleDepth - 1);
-                }
-                if (angleDepth === 0 && (token.value === '(' || token.value === '=' || token.value === ',' || token.value === ';')) {
-                    break;
-                }
-                continue;
-            }
-            if (token.type === 'identifier') {
-                nameTokenIndex = i;
-            }
-        }
-        if (nameTokenIndex === -1) {
-            return null;
-        }
-        const nameToken = tokens[nameTokenIndex];
-        const fieldType = cleanLine.slice(typeStartToken.start, nameToken.start).trim();
-        if (!fieldType) {
-            return null;
-        }
-        const valueTarget = stripTrailingAnnotation(cleanLine.replace(/[,;]\s*$/, ''));
-        const nameRange = this.createRange(
-            this.currentLine,
-            nameToken.start,
-            this.currentLine,
-            nameToken.end
-        );
-        const typeRange = this.createRange(
-            this.currentLine,
-            typeStartToken.start,
-            this.currentLine,
-            nameToken.start
-        );
-        const defaultInfo = findDefaultValueRange(valueTarget);
-        const defaultStart = defaultInfo ? defaultInfo.start : null;
-        const defaultEnd = defaultInfo ? defaultInfo.end : null;
-        return createField({
-            range: this.createRange(this.currentLine, 0, this.currentLine, line.length),
-            nameRange,
-            typeRange,
-            parent,
-            id: parseInt(tokens[idIndex].value, 10),
-            requiredness,
-            fieldType,
-            name: nameToken.value,
-            defaultValue: defaultInfo?.value,
-            defaultValueRange: defaultStart !== null && defaultEnd !== null
-                ? this.createRange(this.currentLine, defaultStart, this.currentLine, defaultEnd)
-                : undefined
-        });
     }
 
     private parseEnum(parent: nodes.ThriftNode, name: string, isSenum: boolean): nodes.Enum {
@@ -656,94 +456,12 @@ export class ThriftParser {
 
     private parseEnumBody(parent: nodes.Enum): number {
         return this.parseBracedBlock((line, scan) => {
-            const member = this.parseEnumMemberLine(parent, line, scan.stripped, scan.tokens);
+            const member = parseEnumMemberLine(parent, line, scan.stripped, scan.tokens, this.currentLine);
             if (member) {
                 parent.members.push(member);
                 this.addChild(parent, member);
             }
         });
-    }
-
-    private parseEnumMemberLine(parent: nodes.Enum, line: string, cleanLine: string, tokens: Token[]): nodes.EnumMember | null {
-        const trimmed = cleanLine.trim();
-        if (!trimmed) {
-            return null;
-        }
-        if (tokens.length === 0) {
-            return null;
-        }
-        const nameToken = tokens.find(token => token.type === 'identifier');
-        if (!nameToken) {
-            return null;
-        }
-        const equalsIndex = findSymbolIndex(tokens, '=');
-        let initializer: string | undefined;
-        let initializerRange: Range | undefined;
-        if (equalsIndex !== -1) {
-            let startOffset: number | null = null;
-            let endOffset: number | null = null;
-            let angleDepth = 0;
-            let bracketDepth = 0;
-            let braceDepth = 0;
-            let parenDepth = 0;
-            for (let i = equalsIndex + 1; i < tokens.length; i++) {
-                const token = tokens[i];
-                if (token.type === 'symbol') {
-                    if (token.value === '<') {
-                        angleDepth += 1;
-                    } else if (token.value === '>') {
-                        angleDepth = Math.max(0, angleDepth - 1);
-                    } else if (token.value === '[') {
-                        bracketDepth += 1;
-                    } else if (token.value === ']') {
-                        bracketDepth = Math.max(0, bracketDepth - 1);
-                    } else if (token.value === '{') {
-                        braceDepth += 1;
-                    } else if (token.value === '}') {
-                        braceDepth = Math.max(0, braceDepth - 1);
-                    } else if (token.value === '(') {
-                        parenDepth += 1;
-                    } else if (token.value === ')') {
-                        parenDepth = Math.max(0, parenDepth - 1);
-                    }
-                    if (angleDepth === 0 && bracketDepth === 0 && braceDepth === 0 && parenDepth === 0 &&
-                        (token.value === ',' || token.value === ';' || token.value === '(')) {
-                        break;
-                    }
-                }
-                startOffset ??= token.start;
-                endOffset = token.end;
-            }
-            if (startOffset !== null && endOffset !== null) {
-                const rawInitializer = cleanLine.slice(startOffset, endOffset).trim();
-                const trimmed = stripTrailingAnnotation(rawInitializer.replace(/[,;]\s*$/, '')).trim();
-                initializer = trimmed || undefined;
-                if (initializer !== undefined && initializer !== '') {
-                    initializerRange = this.createRange(
-                        this.currentLine,
-                        startOffset,
-                        this.currentLine,
-                        endOffset
-                    );
-                }
-            }
-        }
-        initializerRange ??= findInitializerRange(cleanLine, cleanLine, initializer, this.currentLine);
-        const nameRange = this.createRange(
-            this.currentLine,
-            nameToken.start,
-            this.currentLine,
-            nameToken.end
-        );
-        return {
-            type: nodes.ThriftNodeType.EnumMember,
-            range: this.createRange(this.currentLine, 0, this.currentLine, line.length),
-            nameRange,
-            parent: parent,
-            name: nameToken.value,
-            initializer,
-            initializerRange
-        };
     }
 
     private parseService(parent: nodes.ThriftNode, name: string, extendsClass: string | undefined, extendsRange?: Range): nodes.Service {
@@ -785,7 +503,7 @@ export class ThriftParser {
 
     private parseInteractionBody(parent: nodes.Interaction): number {
         return this.parseBracedBlock((line, scan) => {
-            const funcParsed = this.parseServiceFunctionLine(line, scan.stripped, scan.tokens);
+            const funcParsed = parseServiceFunctionLine(line, scan.stripped, scan.tokens, this.currentLine);
             if (funcParsed) {
                 const funcNode = this.buildFunctionNode(parent, funcParsed, line);
                 if (funcNode) {
@@ -798,7 +516,7 @@ export class ThriftParser {
 
     private parseServiceBody(parent: nodes.Service): number {
         return this.parseBracedBlock((line, scan) => {
-            const funcParsed = this.parseServiceFunctionLine(line, scan.stripped, scan.tokens);
+            const funcParsed = parseServiceFunctionLine(line, scan.stripped, scan.tokens, this.currentLine);
             if (funcParsed) {
                 const funcNode = this.buildFunctionNode(parent, funcParsed, line);
                 if (funcNode) {
@@ -806,7 +524,7 @@ export class ThriftParser {
                     this.addChild(parent, funcNode);
                 }
             } else {
-                const perfNode = this.parsePerforms(parent, line, scan.stripped, scan.tokens);
+                const perfNode = parsePerforms(parent, line, scan.stripped, scan.tokens, this.currentLine);
                 if (perfNode) {
                     (parent.performs ??= []).push(perfNode);
                     this.addChild(parent, perfNode);
@@ -815,104 +533,9 @@ export class ThriftParser {
         });
     }
 
-    /**
-     * Scan a line for throws clause starting at `start`, return the index after the throws block.
-     */
-    private skipThrowsBlock(line: string, start: number): number {
-        if (line.substring(start, start + 6) !== 'throws') {
-            return start;
-        }
-        let throwsParenCount = 0;
-        let j = start + 6;
-        for (; j < line.length; j++) {
-            if (line[j] === '(') {
-                throwsParenCount++;
-            } else if (line[j] === ')') {
-                throwsParenCount--;
-                if (throwsParenCount === 0) {
-                    j++;
-                    break;
-                }
-            }
-        }
-        while (j < line.length && /\s/.test(line[j])) {
-            j++;
-        }
-        return j;
-    }
-
-    /**
-     * Find function signature end by scanning for the closing paren after args,
-     * then skipping any throws clause and trailing whitespace.
-     */
-    private findFunctionEnd(
-        startLine: number,
-        startChar: number,
-        initialParenCount: number
-    ): {endLine: number; endChar: number} | null {
-        let parenCount = initialParenCount;
-        for (let lineNum = startLine; lineNum < this.lines.length; lineNum++) {
-            const text = this.lines[lineNum];
-            const colStart = lineNum === startLine ? startChar : 0;
-            for (let i = colStart; i < text.length; i++) {
-                if (text[i] === '(') {
-                    parenCount++;
-                } else if (text[i] === ')') {
-                    parenCount--;
-                    if (parenCount === 0) {
-                        const j = this.skipThrowsBlock(text, i + 1);
-                        if (j < text.length && (text[j] === ',' || text[j] === ';' || text[j] === '{')) {
-                            return {endLine: lineNum, endChar: j + 1};
-                        }
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Parse throws clause if present between args end and function end.
-     */
-    private parseFunctionThrows(
-        argsEndLine: number,
-        argsEndChar: number,
-        funcEndLine: number,
-        funcEndChar: number
-    ): {fields: nodes.Field[]; endLine: number; endChar: number} {
-        const throwsFields: nodes.Field[] = [];
-        let resultEndLine = funcEndLine;
-        let resultEndChar = funcEndChar;
-
-        const throwsStart = findThrowsStartInRange(
-            this.lines, argsEndLine, argsEndChar, funcEndLine, funcEndChar
-        );
-        if (throwsStart) {
-            const throwsResult = readParenthesizedText(this.lines, throwsStart.line, throwsStart.char + 1);
-            if (throwsResult) {
-                throwsFields.push(...parseFieldList(throwsResult.text, throwsStart.line, throwsStart.char + 1));
-                resultEndLine = throwsResult.endLine;
-                resultEndChar = throwsResult.endChar;
-            }
-        }
-        return {fields: throwsFields, endLine: resultEndLine, endChar: resultEndChar};
-    }
-
     private buildFunctionNode(
         parent: nodes.ThriftNode,
-        funcParsed: {
-            name: string;
-            returnType: string;
-            nameRange: Range | undefined;
-            returnTypeRange: Range | undefined;
-            oneway: boolean;
-            isStream: boolean;
-            isSink: boolean;
-            funcStartLine: number;
-            funcStartChar: number;
-            funcEndLine: number;
-            funcEndChar: number;
-        },
+        funcParsed: ParsedServiceFunction,
         line: string
     ): nodes.ThriftFunction | null {
         const {
@@ -941,7 +564,7 @@ export class ThriftParser {
             }
         }
 
-        const end = this.findFunctionEnd(funcStartLine, funcStartChar, 0);
+        const end = findFunctionEnd(this.lines, funcStartLine, funcStartChar, 0);
         if (end) {
             funcEndLine = end.endLine;
             funcEndChar = end.endChar;
@@ -949,7 +572,7 @@ export class ThriftParser {
 
         const argsEndLine = argResult ? argResult.endLine : funcStartLine;
         const argsEndChar = argResult ? argResult.endChar + 1 : Math.max(parenStartPos + 1, funcStartChar);
-        const throws = this.parseFunctionThrows(argsEndLine, argsEndChar, funcEndLine, funcEndChar);
+        const throws = parseFunctionThrows(this.lines, argsEndLine, argsEndChar, funcEndLine, funcEndChar);
         funcEndLine = throws.endLine;
         funcEndChar = throws.endChar;
 
@@ -980,204 +603,10 @@ export class ThriftParser {
         return funcNode;
     }
 
-    /**
-     * 解析 service 或 interaction 中的 performs 声明。
-     */
-    private parsePerforms(parent: nodes.ThriftNode, line: string, cleanLine: string, tokens: Token[]): nodes.Performs | null {
-        const trimmed = cleanLine.trim();
-        if (!trimmed || tokens.length === 0) {
-            return null;
-        }
-        if (tokens[0].type !== 'identifier' || tokens[0].value !== 'performs') {
-            return null;
-        }
-        const nameToken = tokens[1];
-        if (nameToken === undefined || nameToken.type !== 'identifier') {
-            return null;
-        }
-        const nameRange = this.createRange(
-            this.currentLine,
-            nameToken.start,
-            this.currentLine,
-            nameToken.end
-        );
-        return {
-            type: nodes.ThriftNodeType.Performs,
-            range: this.createRange(this.currentLine, 0, this.currentLine, line.length),
-            nameRange,
-            parent: parent,
-            name: nameToken.value,
-            interactionName: nameToken.value,
-            interactionNameRange: nameRange
-        };
-    }
-
-    private parseServiceFunctionLine(line: string, cleanLine: string, tokens: Token[]): {
-        name: string;
-        returnType: string;
-        nameRange: Range | undefined;
-        returnTypeRange: Range | undefined;
-        oneway: boolean;
-        isStream: boolean;
-        isSink: boolean;
-        funcStartLine: number;
-        funcStartChar: number;
-        funcEndLine: number;
-        funcEndChar: number;
-    } | null {
-        const trimmed = cleanLine.trim();
-        if (!trimmed) {
-            return null;
-        }
-        if (tokens.length === 0) {
-            return null;
-        }
-        const parenIndex = findSymbolIndex(tokens, '(');
-        if (parenIndex === -1) {
-            return null;
-        }
-        let nameTokenIndex = -1;
-        for (let i = parenIndex - 1; i >= 0; i--) {
-            if (tokens[i].type === 'identifier') {
-                nameTokenIndex = i;
-                break;
-            }
-        }
-        if (nameTokenIndex === -1) {
-            return null;
-        }
-        const oneway = tokens[0].type === 'identifier' && tokens[0].value === 'oneway';
-        let returnTypeStartIndex = oneway ? 1 : 0;
-        let isStream = false;
-        let isSink = false;
-        // Check for stream/sink prefix after oneway
-        if (returnTypeStartIndex < tokens.length && tokens[returnTypeStartIndex].type === 'identifier') {
-            if (tokens[returnTypeStartIndex].value === 'stream') {
-                isStream = true;
-                returnTypeStartIndex += 1;
-            } else if (tokens[returnTypeStartIndex].value === 'sink') {
-                isSink = true;
-                returnTypeStartIndex += 1;
-            }
-        }
-        const returnTypeStartToken = tokens[returnTypeStartIndex];
-        if (returnTypeStartToken === undefined || returnTypeStartIndex >= nameTokenIndex) {
-            return null;
-        }
-        const nameToken = tokens[nameTokenIndex];
-        // Include stream/sink keyword in return type string
-        const typeStart = isStream ? returnTypeStartIndex - 1 : (isSink ? returnTypeStartIndex - 1 : returnTypeStartIndex);
-        const returnType = cleanLine.slice(tokens[typeStart].start, nameToken.start).trim();
-        if (!returnType) {
-            return null;
-        }
-        const funcStartLine = this.currentLine;
-        const funcStartChar = tokens[typeStart].start;
-        const nameRange = this.createRange(
-            funcStartLine,
-            nameToken.start,
-            funcStartLine,
-            nameToken.end
-        );
-        const returnTypeRange = this.createRange(
-            funcStartLine,
-            tokens[typeStart].start,
-            funcStartLine,
-            nameToken.start
-        );
-        return {
-            name: nameToken.value,
-            returnType,
-            nameRange,
-            returnTypeRange,
-            oneway,
-            isStream,
-            isSink,
-            funcStartLine,
-            funcStartChar,
-            funcEndLine: funcStartLine,
-            funcEndChar: line.length
-        };
-    }
-
     private parseConst(parent: nodes.ThriftNode, valueType: string, name: string): nodes.Const {
-        const startLine = this.currentLine;
-        const line = this.lines[startLine];
-        const keywordIndex = line.indexOf('const');
-        const searchStart = keywordIndex >= 0 ? keywordIndex + 'const'.length : 0;
-        let endLine = this.currentLine;
-        let depthBrace = 0;
-        let depthBracket = 0;
-        let depthParen = 0;
-        let seenEquals = false;
-        let eqLine = -1;
-        let eqChar = -1;
-        const qt = new QuoteTracker();
-
-        while (endLine < this.lines.length) {
-            const line = this.lines[endLine];
-            for (let i = 0; i < line.length; i++) {
-                const ch = line[i];
-                if (qt.inside()) {
-                    qt.feed(ch);
-                    continue;
-                }
-                if (ch === '\'' || ch === '"') {
-                    qt.feed(ch);
-                    continue;
-                }
-                if (ch === '=' && !seenEquals) {
-                    seenEquals = true;
-                    if (eqLine === -1) {
-                        eqLine = endLine;
-                        eqChar = i;
-                    }
-                    continue;
-                }
-                if (!seenEquals) {
-                    continue;
-                }
-                if (ch === '{') {
-                    depthBrace++;
-                }
-                if (ch === '}') {
-                    depthBrace = Math.max(0, depthBrace - 1);
-                }
-                if (ch === '[') {
-                    depthBracket++;
-                }
-                if (ch === ']') {
-                    depthBracket = Math.max(0, depthBracket - 1);
-                }
-                if (ch === '(') {
-                    depthParen++;
-                }
-                if (ch === ')') {
-                    depthParen = Math.max(0, depthParen - 1);
-                }
-            }
-
-            if (seenEquals && depthBrace === 0 && depthBracket === 0 && depthParen === 0) {
-                break;
-            }
-            endLine++;
-        }
-
-        const valueRangeInfo = buildConstValueRange(this.lines, startLine, endLine, eqLine, eqChar);
-        const constNode: nodes.Const = {
-            type: nodes.ThriftNodeType.Const,
-            range: this.createRange(startLine, 0, endLine, (this.lines[endLine] ?? '').length),
-            nameRange: findWordRangeInLine(line, startLine, name, searchStart),
-            parent: parent,
-            valueType: valueType,
-            valueTypeRange: findTypeRangeInLine(line, startLine, valueType, searchStart),
-            name: name,
-            value: valueRangeInfo.value,
-            valueRange: valueRangeInfo.range
-        };
-
-        this.currentLine = endLine + 1;
-        return constNode;
+        const result = parseConstDeclarationNode(parent, this.lines, this.currentLine, valueType, name);
+        this.currentLine = result.endLine + 1;
+        return result.node;
     }
 
     /**

--- a/tests/src/ast/parser/test-golden-ast-fixtures.js
+++ b/tests/src/ast/parser/test-golden-ast-fixtures.js
@@ -9,10 +9,18 @@ function summarize(ast) {
         namespace: node.namespace,
         path: node.path,
         aliasType: node.aliasType,
+        valueType: node.valueType,
+        value: node.value,
+        isSenum: node.isSenum === true,
+        members: node.members && node.members.map(member => ({
+            name: member.name,
+            initializer: member.initializer
+        })),
         fields: node.fields && node.fields.map(field => ({
             name: field.name,
             fieldType: field.fieldType,
-            requiredness: field.requiredness
+            requiredness: field.requiredness,
+            defaultValue: field.defaultValue
         })),
         functions: node.functions && node.functions.map(fn => ({
             name: fn.name,
@@ -22,6 +30,10 @@ function summarize(ast) {
             arguments: fn.arguments.map(arg => ({
                 name: arg.name,
                 fieldType: arg.fieldType
+            })),
+            throws: fn.throws.map(field => ({
+                name: field.name,
+                fieldType: field.fieldType
             }))
         })),
         performs: node.performs && node.performs.map(perform => perform.interactionName)
@@ -56,6 +68,10 @@ describe('golden AST fixtures', function () {
                 namespace: 'demo',
                 path: undefined,
                 aliasType: undefined,
+                valueType: undefined,
+                value: undefined,
+                isSenum: false,
+                members: undefined,
                 fields: undefined,
                 functions: undefined,
                 performs: undefined
@@ -66,6 +82,10 @@ describe('golden AST fixtures', function () {
                 namespace: undefined,
                 path: 'common.thrift',
                 aliasType: undefined,
+                valueType: undefined,
+                value: undefined,
+                isSenum: false,
+                members: undefined,
                 fields: undefined,
                 functions: undefined,
                 performs: undefined
@@ -76,6 +96,10 @@ describe('golden AST fixtures', function () {
                 namespace: undefined,
                 path: undefined,
                 aliasType: 'uuid',
+                valueType: undefined,
+                value: undefined,
+                isSenum: false,
+                members: undefined,
                 fields: undefined,
                 functions: undefined,
                 performs: undefined
@@ -86,9 +110,13 @@ describe('golden AST fixtures', function () {
                 namespace: undefined,
                 path: undefined,
                 aliasType: undefined,
+                valueType: undefined,
+                value: undefined,
+                isSenum: false,
+                members: undefined,
                 fields: [
-                    {name: 'id', fieldType: 'uuid', requiredness: 'required'},
-                    {name: 'parent', fieldType: 'reference User', requiredness: 'optional'}
+                    {name: 'id', fieldType: 'uuid', requiredness: 'required', defaultValue: undefined},
+                    {name: 'parent', fieldType: 'reference User', requiredness: 'optional', defaultValue: undefined}
                 ],
                 functions: undefined,
                 performs: undefined
@@ -99,6 +127,10 @@ describe('golden AST fixtures', function () {
                 namespace: undefined,
                 path: undefined,
                 aliasType: undefined,
+                valueType: undefined,
+                value: undefined,
+                isSenum: false,
+                members: undefined,
                 fields: undefined,
                 functions: [
                     {
@@ -106,7 +138,8 @@ describe('golden AST fixtures', function () {
                         returnType: 'stream<string>',
                         isStream: true,
                         isSink: false,
-                        arguments: [{name: 'events', fieldType: 'sink<string, string>'}]
+                        arguments: [{name: 'events', fieldType: 'sink<string, string>'}],
+                        throws: []
                     }
                 ],
                 performs: undefined
@@ -117,6 +150,10 @@ describe('golden AST fixtures', function () {
                 namespace: undefined,
                 path: undefined,
                 aliasType: undefined,
+                valueType: undefined,
+                value: undefined,
+                isSenum: false,
+                members: undefined,
                 fields: undefined,
                 functions: [
                     {
@@ -124,17 +161,143 @@ describe('golden AST fixtures', function () {
                         returnType: 'stream<User>',
                         isStream: true,
                         isSink: false,
-                        arguments: [{name: 'id', fieldType: 'RequestId'}]
+                        arguments: [{name: 'id', fieldType: 'RequestId'}],
+                        throws: []
                     },
                     {
                         name: 'upload',
                         returnType: 'sink<string, string>',
                         isStream: false,
                         isSink: true,
-                        arguments: [{name: 'payload', fieldType: 'binary'}]
+                        arguments: [{name: 'payload', fieldType: 'binary'}],
+                        throws: []
                     }
                 ],
                 performs: ['ChatInteraction']
+            }
+        ]);
+    });
+
+    it('preserves AST shape for declarations with values, annotations, and throws', function () {
+        const text = [
+            'const map<string, list<i32>> DEFAULT_IDS = {',
+            '  "a": [1, 2],',
+            '  "b": [3]',
+            '}',
+            'enum Status {',
+            '  OK = 1,',
+            '  FAIL = 2 (deprecated="true")',
+            '}',
+            'struct Request {',
+            '  1: required map<string, list<reference Status>> statuses = {"primary": []} (go.tag="json")',
+            '  2: optional string note = "throws should stay a string"',
+            '}',
+            'exception RequestError {',
+            '  1: string message',
+            '}',
+            'service RequestService {',
+            '  Request get(1: uuid id) throws (1: RequestError err)',
+            '}',
+            ''
+        ].join('\n');
+
+        assert.deepStrictEqual(summarize(new ThriftParser(text).parse()), [
+            {
+                type: 'Const',
+                name: 'DEFAULT_IDS',
+                namespace: undefined,
+                path: undefined,
+                aliasType: undefined,
+                valueType: 'map<string, list<i32>>',
+                value: '{\n  "a": [1, 2],\n  "b": [3]\n}',
+                isSenum: false,
+                members: undefined,
+                fields: undefined,
+                functions: undefined,
+                performs: undefined
+            },
+            {
+                type: 'Enum',
+                name: 'Status',
+                namespace: undefined,
+                path: undefined,
+                aliasType: undefined,
+                valueType: undefined,
+                value: undefined,
+                isSenum: false,
+                members: [
+                    {name: 'OK', initializer: '1'},
+                    {name: 'FAIL', initializer: '2'}
+                ],
+                fields: undefined,
+                functions: undefined,
+                performs: undefined
+            },
+            {
+                type: 'Struct',
+                name: 'Request',
+                namespace: undefined,
+                path: undefined,
+                aliasType: undefined,
+                valueType: undefined,
+                value: undefined,
+                isSenum: false,
+                members: undefined,
+                fields: [
+                    {
+                        name: 'statuses',
+                        fieldType: 'map<string, list<reference Status>>',
+                        requiredness: 'required',
+                        defaultValue: '{"primary": []}'
+                    },
+                    {
+                        name: 'note',
+                        fieldType: 'string',
+                        requiredness: 'optional',
+                        defaultValue: '"throws should stay a string"'
+                    }
+                ],
+                functions: undefined,
+                performs: undefined
+            },
+            {
+                type: 'Exception',
+                name: 'RequestError',
+                namespace: undefined,
+                path: undefined,
+                aliasType: undefined,
+                valueType: undefined,
+                value: undefined,
+                isSenum: false,
+                members: undefined,
+                fields: [
+                    {name: 'message', fieldType: 'string', requiredness: undefined, defaultValue: undefined}
+                ],
+                functions: undefined,
+                performs: undefined
+            },
+            {
+                type: 'Service',
+                name: 'RequestService',
+                namespace: undefined,
+                path: undefined,
+                aliasType: undefined,
+                valueType: undefined,
+                value: undefined,
+                isSenum: false,
+                members: undefined,
+                fields: undefined,
+                functions: [
+                    {
+                        name: 'get',
+                        returnType: 'Request',
+                        isStream: false,
+                        isSink: false,
+                        arguments: [{name: 'id', fieldType: 'uuid'}],
+                        throws: [{name: 'err', fieldType: 'RequestError'}]
+                    }
+                ],
+                performs: undefined
             }
         ]);
     });


### PR DESCRIPTION
## Summary
- add broader golden AST coverage for consts, enum initializers, struct defaults, throws, annotations, nested generics, and modern Thrift type forms
- split parser declaration helpers into const, member, and function/performs modules while keeping the public ThriftParser API unchanged
- keep parser.ts focused on parse flow and AST node assembly

## Test Plan
- npm run lint:fix
- npm run lint
- npm run build (fails locally before code build because pnpm 10.25.0 shim is missing at .pnpm-store/.../bin/pnpm ENOENT)
- npm test -- --exit (same pnpm shim failure before mocha)
- node node_modules/.bin/eslint --cache 'packages/*/src/**/*.ts' --fix
- node node_modules/.bin/eslint --cache 'packages/*/src/**/*.ts'
- node node_modules/.bin/tsc -p packages/core/tsconfig.json
- node packages/cli/build.js
- node node_modules/.bin/tsc -p packages/cli/tsconfig.json
- node node_modules/.bin/tsc -p ./
- node build.js
- node node_modules/.bin/mocha --exit (1135 passing)
- node node_modules/.bin/mocha --config .mocharc.single.json tests/src/ast/parser/test-golden-ast-fixtures.js tests/src/ast/parser/test-member-declarations.js tests/src/ast/parser/test-interaction-parsing.js tests/src/formatter/test-ast-roundtrip.js
- npm run perf:benchmark