### PR TITLE
fix(security): harden include and cache boundaries

### DIFF
--- a/packages/cli/src/glob.ts
+++ b/packages/cli/src/glob.ts
@@ -28,7 +28,11 @@ export function expandFiles(patterns: string[]): string[] {
                 continue;
             }
 
-            const stat = fs.statSync(resolved);
+            const stat = fs.lstatSync(resolved);
+            if (stat.isSymbolicLink()) {
+                process.stderr.write(`Warning: "${pattern}" is a symlink, skipping.\n`);
+                continue;
+            }
             if (stat.isFile()) {
                 files.push(resolved);
             } else if (stat.isDirectory()) {

--- a/packages/core/src/ast/cache.ts
+++ b/packages/core/src/ast/cache.ts
@@ -33,6 +33,8 @@ interface ASTRegionCacheEntry {
 const astCache = new Map<string, ASTCacheEntry>();
 const astRegionCache = new Map<string, ASTRegionCacheEntry[]>(); // Keyed by URI
 const CACHE_MAX_AGE = config.cache.astMaxAgeMs;
+const AST_FULL_MAX_SIZE = CACHE_CONFIGS['ast-full'].maxSize;
+const AST_REGION_MAX_URIS = CACHE_CONFIGS['ast-region'].maxSize;
 
 /**
  * 获取缓存中的 AST（若命中且未过期）。
@@ -143,6 +145,7 @@ export function setCachedAstRange(uri: string, range: LineRange, content: string
     if (uriCache.length > 50) { // Use a reasonable constant instead of config value
         uriCache.shift(); // Remove oldest entry
     }
+    pruneRegionCacheUris();
 
     // Notify the cache manager about the set operation for memory awareness
     cacheManager.set('ast-region', makeUriRangeKey(uri, range), ast);
@@ -183,6 +186,7 @@ export function setCachedAst(uri: string, content: string, ast: nodes.ThriftDocu
     const cacheKey = makeUriContentKey(uri, content, version);
 
     astCache.set(cacheKey, entry);
+    pruneFullAstCache();
 
     // Notify the cache manager about the set operation for memory awareness
     cacheManager.set('ast-full', cacheKey, entry);
@@ -252,4 +256,61 @@ export function parseWithAstCache(
     const ast = parse();
     setCachedAst(uri, content, ast, version);
     return ast;
+}
+
+function pruneFullAstCache(): void {
+    pruneOldestEntries(astCache, AST_FULL_MAX_SIZE, (key) => cacheManager.delete('ast-full', key));
+}
+
+function pruneRegionCacheUris(): void {
+    while (astRegionCache.size > AST_REGION_MAX_URIS) {
+        let oldestUri: string | undefined;
+        let oldestTimestamp = Number.POSITIVE_INFINITY;
+        for (const [uri, entries] of astRegionCache.entries()) {
+            const timestamp = entries.reduce(
+                (oldest, entry) => Math.min(oldest, entry.timestamp),
+                Number.POSITIVE_INFINITY
+            );
+            if (timestamp < oldestTimestamp) {
+                oldestTimestamp = timestamp;
+                oldestUri = uri;
+            }
+        }
+        if (oldestUri === undefined) {
+            return;
+        }
+        clearAstRegionCacheForDocument(oldestUri);
+    }
+}
+
+function pruneOldestEntries<T extends {timestamp: number}>(
+    cache: Map<string, T>,
+    maxSize: number,
+    onDelete: (key: string) => void
+): void {
+    while (cache.size > maxSize) {
+        let oldestKey: string | undefined;
+        let oldestTimestamp = Number.POSITIVE_INFINITY;
+        for (const [key, entry] of cache.entries()) {
+            if (entry.timestamp < oldestTimestamp) {
+                oldestTimestamp = entry.timestamp;
+                oldestKey = key;
+            }
+        }
+        if (oldestKey === undefined) {
+            return;
+        }
+        cache.delete(oldestKey);
+        onDelete(oldestKey);
+    }
+}
+
+/**
+ * Test-only cache statistics. Do not use for production behavior.
+ */
+export function getAstCacheStatsForTesting(): {fullSize: number; regionUriSize: number} {
+    return {
+        fullSize: astCache.size,
+        regionUriSize: astRegionCache.size
+    };
 }

--- a/packages/vscode/src/include-document-link-provider.ts
+++ b/packages/vscode/src/include-document-link-provider.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import {collectIncludes, ThriftParser} from '@tanzz/thrift-core';
+import {collectIncludes, safeResolveIncludePath, ThriftParser} from '@tanzz/thrift-core';
 import {CoreDependencies} from './utils/dependencies';
 import {ErrorHandler} from '@tanzz/thrift-core';
 
@@ -29,7 +29,13 @@ export class ThriftIncludeDocumentLinkProvider implements vscode.DocumentLinkPro
                 if (range === undefined) {
                     continue;
                 }
-                const target = vscode.Uri.file(path.resolve(path.dirname(document.uri.fsPath), includeNode.path));
+                const documentDir = path.dirname(document.uri.fsPath);
+                const workspaceRoot = getWorkspaceRootForDocument(document.uri) ?? documentDir;
+                const targetPath = safeResolveIncludePath(includeNode.path, documentDir, workspaceRoot);
+                if (targetPath === undefined) {
+                    continue;
+                }
+                const target = vscode.Uri.file(targetPath);
                 links.push({range, target});
             }
             return links;
@@ -49,6 +55,16 @@ export function registerIncludeDocumentLinkProvider(context: vscode.ExtensionCon
     context.subscriptions.push(
         vscode.languages.registerDocumentLinkProvider('thrift', new ThriftIncludeDocumentLinkProvider(deps))
     );
+}
+
+function getWorkspaceRootForDocument(uri: vscode.Uri): string | undefined {
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+        const relative = path.relative(folder.uri.fsPath, uri.fsPath);
+        if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+            return folder.uri.fsPath;
+        }
+    }
+    return undefined;
 }
 
 function findIncludePathRange(line: string, lineNumber: number, includePath: string): vscode.Range | undefined {

--- a/packages/vscode/src/indexing/workspace-index.ts
+++ b/packages/vscode/src/indexing/workspace-index.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import {collectTopLevelTypes, nodes, ThriftParser} from '@tanzz/thrift-core';
+import {collectTopLevelTypes, config, nodes, safeResolveIncludePath, ThriftParser} from '@tanzz/thrift-core';
 import {createLocation, toVscodeRange} from '../utils/vscode-utils';
 import {IndexedThriftSymbol, SymbolIndex} from './symbol-index';
 
@@ -8,6 +8,7 @@ export interface WorkspaceIndexDeps {
     findFiles?: () => Thenable<vscode.Uri[]> | Promise<vscode.Uri[]>;
     readFile?: (uri: vscode.Uri) => Thenable<string> | Promise<string>;
     createWatcher?: (invalidate: (uri?: vscode.Uri) => void) => vscode.Disposable;
+    workspaceFolders?: vscode.Uri[];
 }
 
 interface IndexedInclude {
@@ -123,7 +124,11 @@ export class WorkspaceIndex implements vscode.Disposable {
         if (this.deps.findFiles) {
             return this.deps.findFiles();
         }
-        return vscode.workspace.findFiles('**/*.thrift', '**/node_modules/**');
+        return vscode.workspace.findFiles(
+            config.filePatterns.thrift,
+            config.filePatterns.excludeNodeModules,
+            config.search.workspaceFileLimit
+        );
     }
 
     private async readFile(uri: vscode.Uri): Promise<string> {
@@ -159,9 +164,13 @@ export class WorkspaceIndex implements vscode.Disposable {
             if (node.type !== nodes.ThriftNodeType.Include) {
                 continue;
             }
+            const includeUri = this.resolveIncludeUri(uri, node.path);
+            if (includeUri === undefined) {
+                continue;
+            }
             includes.push({
                 path: node.path,
-                uri: this.resolveIncludeUri(uri, node.path),
+                uri: includeUri,
                 range: toVscodeRange(node.range)
             });
         }
@@ -178,11 +187,27 @@ export class WorkspaceIndex implements vscode.Disposable {
         return namespaces;
     }
 
-    private resolveIncludeUri(sourceUri: vscode.Uri, includePath: string): vscode.Uri {
-        if (path.isAbsolute(includePath)) {
-            return vscode.Uri.file(path.normalize(includePath));
+    private resolveIncludeUri(sourceUri: vscode.Uri, includePath: string): vscode.Uri | undefined {
+        const sourceDir = path.dirname(sourceUri.fsPath);
+        const boundaryDir = this.getBoundaryDir(sourceUri) ?? sourceDir;
+        const resolved = safeResolveIncludePath(includePath, sourceDir, boundaryDir);
+        if (resolved === undefined) {
+            return undefined;
         }
-        return vscode.Uri.file(path.normalize(path.resolve(path.dirname(sourceUri.fsPath), includePath)));
+        return vscode.Uri.file(resolved);
+    }
+
+    private getBoundaryDir(sourceUri: vscode.Uri): string | undefined {
+        const folders = this.deps.workspaceFolders ??
+            vscode.workspace.workspaceFolders?.map(folder => folder.uri) ??
+            [];
+        for (const folder of folders) {
+            const relative = path.relative(folder.fsPath, sourceUri.fsPath);
+            if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+                return folder.fsPath;
+            }
+        }
+        return undefined;
     }
 
     private rebuildSymbols(): void {

--- a/tests/cli/test-cli-units.js
+++ b/tests/cli/test-cli-units.js
@@ -262,6 +262,25 @@ describe('CLI unit tests', () => {
             }
         });
 
+        it('skips direct symlink file arguments', function () {
+            if (process.platform === 'win32') {
+                this.skip();
+            }
+
+            const d = tmpDir('cli-glob-symlink-');
+            try {
+                const real = path.join(d, 'real.thrift');
+                const link = path.join(d, 'link.thrift');
+                fs.writeFileSync(real, 'struct A {}');
+                fs.symlinkSync(real, link);
+
+                const result = globMod.expandFiles([link]);
+                assert.deepStrictEqual(result, []);
+            } finally {
+                fs.rmSync(d, {recursive: true, force: true});
+            }
+        });
+
         it('expands a directory to all .thrift files', () => {
             const d = tmpDir('cli-glob-dir-');
             try {

--- a/tests/src/ast/parser/test-ast-caching.js
+++ b/tests/src/ast/parser/test-ast-caching.js
@@ -140,4 +140,19 @@ describe('AST caching', () => {
     it('should pass testCacheStatistics', () => {
         testCacheStatistics();
     });
+    it('bounds full AST cache entries by configured capacity', () => {
+        const cache = require('../../../../out/ast/cache.js');
+        assert.strictEqual(typeof cache.getAstCacheStatsForTesting, 'function');
+
+        cache.clearExpiredAstCache();
+        for (let i = 0; i < 130; i++) {
+            ThriftParser.parseContentWithCache(
+                `bounded-cache-${i}.thrift`,
+                `struct Bounded${i} { 1: string field${i} }`
+            );
+        }
+
+        const stats = cache.getAstCacheStatsForTesting();
+        assert.ok(stats.fullSize <= 100, `expected full cache size <= 100, got ${stats.fullSize}`);
+    });
 });

--- a/tests/src/include-document-link-provider/test-include-document-link-provider.js
+++ b/tests/src/include-document-link-provider/test-include-document-link-provider.js
@@ -45,4 +45,24 @@ describe('ThriftIncludeDocumentLinkProvider', function () {
         assert.deepStrictEqual(await provider.provideDocumentLinks(textDocument, {isCancellationRequested: false}), []);
         assert.deepStrictEqual(await provider.provideDocumentLinks(thriftDocument, {isCancellationRequested: true}), []);
     });
+
+    it('does not create links for include paths outside the workspace root', async function () {
+        const provider = new ThriftIncludeDocumentLinkProvider();
+        const document = createDocument(
+            '/tmp/thrift-links/main.thrift',
+            'include "../outside.thrift"\ninclude "/etc/passwd"\ninclude "shared.thrift"\n'
+        );
+
+        const originalWorkspaceFolders = vscode.workspace.workspaceFolders;
+        vscode.workspace.workspaceFolders = [{uri: vscode.Uri.file('/tmp/thrift-links')}];
+
+        try {
+            const links = await provider.provideDocumentLinks(document, {isCancellationRequested: false});
+            assert.deepStrictEqual(links.map(link => link.target.fsPath), [
+                path.join('/tmp', 'thrift-links', 'shared.thrift')
+            ]);
+        } finally {
+            vscode.workspace.workspaceFolders = originalWorkspaceFolders;
+        }
+    });
 });

--- a/tests/src/indexing/test-workspace-index.js
+++ b/tests/src/indexing/test-workspace-index.js
@@ -26,4 +26,61 @@ describe('WorkspaceIndex', function () {
         assert.strictEqual(user[0].name, 'User');
         assert.strictEqual(service[0].name, 'UserService');
     });
+
+    it('drops include paths that escape the workspace root', async function () {
+        const {WorkspaceIndex} = require('../../../out/indexing/workspace-index');
+
+        const files = new Map([
+            ['/workspace/service.thrift', 'include "../outside.thrift"\ninclude "/etc/passwd"\ninclude "shared.thrift"\nservice UserService { void ping() }\n'],
+            ['/workspace/shared.thrift', 'struct Shared { 1: string name }\n']
+        ]);
+        const reads = [];
+
+        const index = new WorkspaceIndex({
+            workspaceFolders: [vscode.Uri.file('/workspace')],
+            findFiles: async () => [vscode.Uri.file('/workspace/service.thrift')],
+            readFile: async uri => {
+                reads.push(uri.fsPath);
+                return files.get(uri.fsPath) || '';
+            },
+            createWatcher: () => ({dispose() {}})
+        });
+
+        await index.refresh();
+
+        const includes = index.getIncludedUris(vscode.Uri.file('/workspace/service.thrift'));
+        assert.deepStrictEqual(includes.map(uri => uri.fsPath), ['/workspace/shared.thrift']);
+
+        const liveIncludes = index.getIncludedUrisForText(
+            vscode.Uri.file('/workspace/service.thrift'),
+            files.get('/workspace/service.thrift'),
+            2
+        );
+        assert.deepStrictEqual(liveIncludes.map(uri => uri.fsPath), ['/workspace/shared.thrift']);
+
+        await index.getText(includes[0]);
+        assert.deepStrictEqual(reads.sort(), ['/workspace/service.thrift', '/workspace/shared.thrift'].sort());
+    });
+
+    it('limits default workspace indexing to the configured file budget', async function () {
+        const {WorkspaceIndex} = require('../../../out/indexing/workspace-index');
+        const originalFindFiles = vscode.workspace.findFiles;
+        const calls = [];
+
+        vscode.workspace.findFiles = async (include, exclude, maxResults) => {
+            calls.push({include, exclude, maxResults});
+            return [];
+        };
+
+        try {
+            const index = new WorkspaceIndex({createWatcher: () => ({dispose() {}})});
+            await index.refresh();
+        } finally {
+            vscode.workspace.findFiles = originalFindFiles;
+        }
+
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(typeof calls[0].maxResults, 'number');
+        assert.ok(calls[0].maxResults > 0, 'maxResults should be a positive bound');
+    });
 });


### PR DESCRIPTION
## Summary
- constrain include resolution for workspace indexing and document links to workspace boundaries
- skip direct symlink file arguments in the CLI glob expansion path
- bound full AST and region cache growth and add regression coverage

## Verification
- npm run lint
- npm run build
- npm test