### PR TITLE
fix(definition): avoid resolving references as definitions

### DIFF
--- a/packages/vscode/src/definition-provider.ts
+++ b/packages/vscode/src/definition-provider.ts
@@ -142,7 +142,12 @@ export class ThriftDefinitionProvider implements vscode.DefinitionProvider {
         }
 
         // Search in current document
-        const currentDocDefinition = this.definitionLookup.findDefinitionInDocument(document.uri, document.getText(), searchTypeName);
+        const currentDocDefinition = this.definitionLookup.findDefinitionInDocument(
+            document.uri,
+            document.getText(),
+            searchTypeName,
+            wordRange
+        );
         if (currentDocDefinition) {
             return currentDocDefinition;
         }

--- a/packages/vscode/src/definition/lookup.ts
+++ b/packages/vscode/src/definition/lookup.ts
@@ -15,12 +15,15 @@ export class DefinitionLookup {
     public findDefinitionInDocument(
         uri: vscode.Uri,
         text: string,
-        typeName: string
+        typeName: string,
+        sourceRange?: vscode.Range
     ): vscode.Location | undefined {
-        const cacheKey = `document_${uri.toString()}_${typeName}`;
-        const cached = this.cacheManager.get<vscode.Location[]>('document', cacheKey);
-        if (cached && cached.length > 0) {
-            return cached[0];
+        const cacheKey = sourceRange === undefined ? `document_${uri.toString()}_${typeName}_${hashText(text)}` : undefined;
+        if (cacheKey !== undefined) {
+            const cached = this.cacheManager.get<vscode.Location[]>('document', cacheKey);
+            if (cached && cached.length > 0) {
+                return cached[0];
+            }
         }
 
         const parser = new ThriftParser(text);
@@ -28,15 +31,21 @@ export class DefinitionLookup {
 
         let foundLocation: vscode.Location | undefined;
         this.traverseAST(ast, (node) => {
-            if (node.name === typeName) {
-                foundLocation = createLocation(uri, node.range);
-                return false;
+            if (isDefinitionNode(node) && node.name === typeName) {
+                const location = createLocation(uri, node.range);
+                if (sourceRange !== undefined && rangeContainsNodeName(node, sourceRange)) {
+                    foundLocation = location;
+                    return false;
+                }
+                foundLocation ??= location;
             }
             return true;
         });
 
         const locations = foundLocation ? [foundLocation] : [];
-        this.cacheManager.set('document', cacheKey, locations);
+        if (cacheKey !== undefined) {
+            this.cacheManager.set('document', cacheKey, locations);
+        }
         return foundLocation;
     }
 
@@ -142,4 +151,34 @@ export class DefinitionLookup {
 
         return true;
     }
+}
+
+function rangeContainsNodeName(node: nodes.ThriftNode, sourceRange: vscode.Range): boolean {
+    if (node.nameRange === undefined) {
+        return false;
+    }
+    return node.nameRange.start.line === sourceRange.start.line &&
+        sourceRange.start.character >= node.nameRange.start.character &&
+        sourceRange.end.character <= node.nameRange.end.character;
+}
+
+function isDefinitionNode(node: nodes.ThriftNode): boolean {
+    return node.type === nodes.ThriftNodeType.Const ||
+        node.type === nodes.ThriftNodeType.Typedef ||
+        node.type === nodes.ThriftNodeType.Enum ||
+        node.type === nodes.ThriftNodeType.EnumMember ||
+        node.type === nodes.ThriftNodeType.Struct ||
+        node.type === nodes.ThriftNodeType.Union ||
+        node.type === nodes.ThriftNodeType.Exception ||
+        node.type === nodes.ThriftNodeType.Service ||
+        node.type === nodes.ThriftNodeType.Interaction ||
+        node.type === nodes.ThriftNodeType.Function;
+}
+
+function hashText(text: string): string {
+    let hash = 0;
+    for (let i = 0; i < text.length; i++) {
+        hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0;
+    }
+    return hash.toString(36);
 }

--- a/tests/src/definition-provider/test-definition-provider.js
+++ b/tests/src/definition-provider/test-definition-provider.js
@@ -148,6 +148,77 @@ struct Profile {
         assert(structDefinition.range.end.line === 3, 'Definition should end at line 3');
     });
 
+    it('should ignore previous field names when resolving a later struct type reference', async () => {
+        const structText = `struct Earlier {
+    1: required User User
+}
+
+struct Later {
+    1: required User User
+}
+
+struct User {
+    1: required string name
+}`;
+        const structDocument = createMockDocument(structText);
+        const structPosition = createMockPosition(5, 18); // On "User" type in Later
+
+        const structDefinition = await provider.provideDefinition(
+            structDocument,
+            structPosition,
+            createMockCancellationToken()
+        );
+
+        assert(structDefinition, 'Should find definition for struct type');
+        assert.strictEqual(structDefinition.range.start.line, 8, 'Struct definition should be at line 8');
+    });
+
+    it('should ignore previous field names when resolving a later enum type reference', async () => {
+        const enumText = `struct Earlier {
+    1: required Status Status
+}
+
+struct Later {
+    1: required Status Status
+}
+
+enum Status {
+    ACTIVE = 1
+}`;
+        const enumDocument = createMockDocument(enumText);
+        const enumPosition = createMockPosition(5, 18); // On "Status" type in Later
+
+        const enumDefinition = await provider.provideDefinition(
+            enumDocument,
+            enumPosition,
+            createMockCancellationToken()
+        );
+
+        assert(enumDefinition, 'Should find definition for enum type');
+        assert.strictEqual(enumDefinition.range.start.line, 8, 'Enum definition should be at line 8');
+    });
+
+    it('should resolve a later service method occurrence to its own declaration', async () => {
+        const serviceText = `service LegacyUserService {
+    void getUser(1: i32 id)
+}
+
+service UserService {
+    void getUser(1: i32 id)
+}`;
+        const serviceDocument = createMockDocument(serviceText);
+        const methodPosition = createMockPosition(5, 10); // On "getUser" method in UserService
+
+        const methodDefinition = await provider.provideDefinition(
+            serviceDocument,
+            methodPosition,
+            createMockCancellationToken()
+        );
+
+        assert(methodDefinition, 'Should find definition for service method');
+        assert.strictEqual(methodDefinition.range.start.line, 5, 'Method definition should be the later declaration');
+    });
+
     it('should find definition of enum type', async () => {
         const enumText = `enum Status {
     ACTIVE = 1,


### PR DESCRIPTION
## Summary
- restrict current-document definition lookup to real declaration nodes so fields/arguments are not treated as definitions
- use cursor context to keep later same-named method declarations from jumping to earlier methods
- include document text in lookup cache keys to avoid stale same-URI results

## Tests
- pnpm run lint
- pnpm run build
- pnpm test