### PR TITLE
fix(navigation): avoid symbol kind collisions

### DIFF
--- a/packages/vscode/src/definition/lookup.ts
+++ b/packages/vscode/src/definition/lookup.ts
@@ -31,13 +31,15 @@ export class DefinitionLookup {
 
         let foundLocation: vscode.Location | undefined;
         this.traverseAST(ast, (node) => {
-            if (isDefinitionNode(node) && node.name === typeName) {
+            if (isCurrentDeclarationCandidate(node) && node.name === typeName) {
                 const location = createLocation(uri, node.range);
                 if (sourceRange !== undefined && rangeContainsNodeName(node, sourceRange)) {
                     foundLocation = location;
                     return false;
                 }
-                foundLocation ??= location;
+                if (isLookupTargetNode(node)) {
+                    foundLocation ??= location;
+                }
             }
             return true;
         });
@@ -162,7 +164,7 @@ function rangeContainsNodeName(node: nodes.ThriftNode, sourceRange: vscode.Range
         sourceRange.end.character <= node.nameRange.end.character;
 }
 
-function isDefinitionNode(node: nodes.ThriftNode): boolean {
+function isCurrentDeclarationCandidate(node: nodes.ThriftNode): boolean {
     return node.type === nodes.ThriftNodeType.Const ||
         node.type === nodes.ThriftNodeType.Typedef ||
         node.type === nodes.ThriftNodeType.Enum ||
@@ -173,6 +175,17 @@ function isDefinitionNode(node: nodes.ThriftNode): boolean {
         node.type === nodes.ThriftNodeType.Service ||
         node.type === nodes.ThriftNodeType.Interaction ||
         node.type === nodes.ThriftNodeType.Function;
+}
+
+function isLookupTargetNode(node: nodes.ThriftNode): boolean {
+    return node.type === nodes.ThriftNodeType.Const ||
+        node.type === nodes.ThriftNodeType.Typedef ||
+        node.type === nodes.ThriftNodeType.Enum ||
+        node.type === nodes.ThriftNodeType.Struct ||
+        node.type === nodes.ThriftNodeType.Union ||
+        node.type === nodes.ThriftNodeType.Exception ||
+        node.type === nodes.ThriftNodeType.Service ||
+        node.type === nodes.ThriftNodeType.Interaction;
 }
 
 function hashText(text: string): string {

--- a/packages/vscode/src/document-highlight-provider.ts
+++ b/packages/vscode/src/document-highlight-provider.ts
@@ -3,6 +3,7 @@ import {ThriftParser, nodes, ErrorHandler, parseContainerTypeInfo} from '@tanzz/
 import {CoreDependencies} from './utils/dependencies';
 import {toVscodeRange} from './utils/vscode-utils';
 import {PRIMITIVE_TYPES, CONTAINER_KEYWORDS} from './utils/thrift-constants';
+import {getSymbolType} from './references/symbol-type';
 
 interface SimpleRange {
     start: {line: number; character: number};
@@ -24,7 +25,8 @@ export interface HighlightOccurrence {
  */
 export function collectHighlights(
     ast: nodes.ThriftDocument,
-    target: string
+    target: string,
+    symbolType = 'any'
 ): HighlightOccurrence[] {
     if (!target) {
         return [];
@@ -61,27 +63,31 @@ export function collectHighlights(
     const visit = (node: nodes.ThriftNode): void => {
         switch (node.type) {
             case nodes.ThriftNodeType.Namespace: {
-                if (node.name === target) {
+                if (shouldIncludeNameHighlight(node, symbolType) && node.name === target) {
                     pushIfRange(node.nameRange, vscode.DocumentHighlightKind.Write);
                 }
                 break;
             }
             case nodes.ThriftNodeType.Const: {
-                if (node.name === target) {
+                if (shouldIncludeNameHighlight(node, symbolType) && node.name === target) {
                     pushIfRange(node.nameRange, vscode.DocumentHighlightKind.Write);
                 }
-                matchTypeText(node.valueType, node.valueTypeRange);
+                if (shouldIncludeTypeReferences(symbolType)) {
+                    matchTypeText(node.valueType, node.valueTypeRange);
+                }
                 break;
             }
             case nodes.ThriftNodeType.Typedef: {
-                if (node.name === target) {
+                if (shouldIncludeNameHighlight(node, symbolType) && node.name === target) {
                     pushIfRange(node.nameRange, vscode.DocumentHighlightKind.Write);
                 }
-                matchTypeText(node.aliasType, node.aliasTypeRange);
+                if (shouldIncludeTypeReferences(symbolType)) {
+                    matchTypeText(node.aliasType, node.aliasTypeRange);
+                }
                 break;
             }
             case nodes.ThriftNodeType.Enum: {
-                if (node.name === target) {
+                if (shouldIncludeNameHighlight(node, symbolType) && node.name === target) {
                     pushIfRange(node.nameRange, vscode.DocumentHighlightKind.Write);
                 }
                 for (const member of node.members) {
@@ -90,7 +96,7 @@ export function collectHighlights(
                 break;
             }
             case nodes.ThriftNodeType.EnumMember: {
-                if (node.name === target) {
+                if (shouldIncludeNameHighlight(node, symbolType) && node.name === target) {
                     pushIfRange(node.nameRange, vscode.DocumentHighlightKind.Write);
                 }
                 break;
@@ -98,7 +104,7 @@ export function collectHighlights(
             case nodes.ThriftNodeType.Struct:
             case nodes.ThriftNodeType.Union:
             case nodes.ThriftNodeType.Exception: {
-                if (node.name === target) {
+                if (shouldIncludeNameHighlight(node, symbolType) && node.name === target) {
                     pushIfRange(node.nameRange, vscode.DocumentHighlightKind.Write);
                 }
                 for (const field of node.fields) {
@@ -107,11 +113,11 @@ export function collectHighlights(
                 break;
             }
             case nodes.ThriftNodeType.Service: {
-                if (node.name === target) {
+                if (shouldIncludeNameHighlight(node, symbolType) && node.name === target) {
                     pushIfRange(node.nameRange, vscode.DocumentHighlightKind.Write);
                 }
                 // service extends target → Read
-                if (node.extends === target) {
+                if (shouldIncludeTypeReferences(symbolType) && node.extends === target) {
                     pushIfRange(node.extendsRange ?? node.nameRange, vscode.DocumentHighlightKind.Read);
                 }
                 for (const func of node.functions) {
@@ -125,7 +131,7 @@ export function collectHighlights(
                 break;
             }
             case nodes.ThriftNodeType.Interaction: {
-                if (node.name === target) {
+                if (shouldIncludeNameHighlight(node, symbolType) && node.name === target) {
                     pushIfRange(node.nameRange, vscode.DocumentHighlightKind.Write);
                 }
                 for (const func of node.functions) {
@@ -134,16 +140,18 @@ export function collectHighlights(
                 break;
             }
             case nodes.ThriftNodeType.Performs: {
-                if (node.interactionName === target) {
+                if (shouldIncludeTypeReferences(symbolType) && node.interactionName === target) {
                     pushIfRange(node.interactionNameRange, vscode.DocumentHighlightKind.Read);
                 }
                 break;
             }
             case nodes.ThriftNodeType.Function: {
-                if (node.name === target) {
+                if (shouldIncludeNameHighlight(node, symbolType) && node.name === target) {
                     pushIfRange(node.nameRange, vscode.DocumentHighlightKind.Write);
                 }
-                matchTypeText(node.returnType, node.returnTypeRange);
+                if (shouldIncludeTypeReferences(symbolType)) {
+                    matchTypeText(node.returnType, node.returnTypeRange);
+                }
                 for (const arg of node.arguments) {
                     visit(arg);
                 }
@@ -153,10 +161,12 @@ export function collectHighlights(
                 break;
             }
             case nodes.ThriftNodeType.Field: {
-                if (node.name === target) {
+                if (shouldIncludeNameHighlight(node, symbolType) && node.name === target) {
                     pushIfRange(node.nameRange, vscode.DocumentHighlightKind.Write);
                 }
-                matchTypeText(node.fieldType, node.typeRange);
+                if (shouldIncludeTypeReferences(symbolType)) {
+                    matchTypeText(node.fieldType, node.typeRange);
+                }
                 break;
             }
             default:
@@ -169,6 +179,57 @@ export function collectHighlights(
     }
 
     return dedupe(out);
+}
+
+function shouldIncludeTypeReferences(symbolType: string): boolean {
+    return symbolType === 'any' ||
+        symbolType === 'type' ||
+        symbolType === 'struct' ||
+        symbolType === 'union' ||
+        symbolType === 'exception' ||
+        symbolType === 'enum' ||
+        symbolType === 'service' ||
+        symbolType === 'interaction' ||
+        symbolType === 'typedef' ||
+        symbolType === 'namespace';
+}
+
+function shouldIncludeNameHighlight(node: nodes.ThriftNode, symbolType: string): boolean {
+    if (symbolType === 'any') {
+        return true;
+    }
+    switch (symbolType) {
+        case 'field':
+            return node.type === nodes.ThriftNodeType.Field;
+        case 'method':
+            return node.type === nodes.ThriftNodeType.Function;
+        case 'enumValue':
+            return node.type === nodes.ThriftNodeType.EnumMember;
+        case 'struct':
+        case 'union':
+        case 'exception':
+        case 'enum':
+        case 'service':
+        case 'interaction':
+        case 'typedef':
+        case 'type':
+        case 'namespace':
+            return shouldIncludeTypeName(node);
+        default:
+            return false;
+    }
+}
+
+function shouldIncludeTypeName(node: nodes.ThriftNode): boolean {
+    return node.type === nodes.ThriftNodeType.Namespace ||
+        node.type === nodes.ThriftNodeType.Const ||
+        node.type === nodes.ThriftNodeType.Typedef ||
+        node.type === nodes.ThriftNodeType.Enum ||
+        node.type === nodes.ThriftNodeType.Struct ||
+        node.type === nodes.ThriftNodeType.Union ||
+        node.type === nodes.ThriftNodeType.Exception ||
+        node.type === nodes.ThriftNodeType.Service ||
+        node.type === nodes.ThriftNodeType.Interaction;
 }
 
 function dedupe(occurrences: HighlightOccurrence[]): HighlightOccurrence[] {
@@ -253,7 +314,13 @@ export class ThriftDocumentHighlightProvider implements vscode.DocumentHighlight
                 document.getText(),
                 document.version
             );
-            const occurrences = collectHighlights(ast, target);
+            const symbolType = getSymbolType(document, position, target, {
+                getCachedAst: () => ast
+            });
+            if (symbolType === null) {
+                return [];
+            }
+            const occurrences = collectHighlights(ast, target, symbolType);
             return occurrences.map(o => new vscode.DocumentHighlight(toVscodeRange(o.range), o.kind));
         } catch (error) {
             this.errorHandler.handleError(error, {

--- a/packages/vscode/src/references-provider.ts
+++ b/packages/vscode/src/references-provider.ts
@@ -63,6 +63,7 @@ export class ThriftReferencesProvider implements vscode.ReferenceProvider {
         }
 
         const symbolName = document.getText(wordRange);
+        const documentText = document.getText();
         const symbolType = getSymbolType(document, position, symbolName, {
             getCachedAst: (doc) => this.astCache.get(doc)
         });
@@ -78,7 +79,8 @@ export class ThriftReferencesProvider implements vscode.ReferenceProvider {
         }
 
         // 创建缓存键
-        const cacheKey = `${document.uri.fsPath}:${symbolName}:${symbolType}`;
+        const includeDeclaration = context?.includeDeclaration === true;
+        const cacheKey = `${document.uri.fsPath}:${symbolName}:${symbolType}:${includeDeclaration}:${hashText(documentText)}`;
 
         // 使用缓存管理器检查缓存
         const cacheName = 'references';
@@ -87,13 +89,12 @@ export class ThriftReferencesProvider implements vscode.ReferenceProvider {
             return cachedReferences;
         }
 
-        const includeDeclaration = context?.includeDeclaration;
-
         // Search in current document
         const currentDocRefs = findReferencesInDocument(
             document.uri,
-            document.getText(),
+            documentText,
             symbolName,
+            symbolType,
             includeDeclaration,
             {errorHandler: this.errorHandler},
             token
@@ -139,6 +140,7 @@ export class ThriftReferencesProvider implements vscode.ReferenceProvider {
                         file,
                         text,
                         symbolName,
+                        symbolType,
                         includeDeclaration,
                         {errorHandler: this.errorHandler},
                         token
@@ -203,6 +205,14 @@ export class ThriftReferencesProvider implements vscode.ReferenceProvider {
         }
         return readThriftFile(uri);
     }
+}
+
+function hashText(text: string): string {
+    let hash = 0;
+    for (let i = 0; i < text.length; i++) {
+        hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0;
+    }
+    return hash.toString(36);
 }
 
 /**

--- a/packages/vscode/src/references/reference-search.ts
+++ b/packages/vscode/src/references/reference-search.ts
@@ -23,6 +23,7 @@ export function findReferencesInDocument(
     uri: vscode.Uri,
     text: string,
     symbolName: string,
+    symbolType: string,
     includeDeclaration: boolean,
     deps: ReferenceSearchDeps,
     token?: vscode.CancellationToken
@@ -101,6 +102,13 @@ export function findReferencesInDocument(
             return definitionTypes.includes(n.type);
         };
 
+        if (!isTypeSymbol(symbolType)) {
+            if (includeDeclaration && node.name === symbolName && isSymbolTypeDeclaration(node, symbolType)) {
+                references.push(createLocation(uri, node.nameRange ?? node.range));
+            }
+            return;
+        }
+
         if (includeDeclaration && node.name === symbolName && isDefinitionNode(node)) {
             references.push(createLocation(uri, node.nameRange ?? node.range));
             return;
@@ -145,4 +153,29 @@ export function findReferencesInDocument(
     }, contextCallback);
 
     return references;
+}
+
+function isTypeSymbol(symbolType: string): boolean {
+    return symbolType === 'type' ||
+        symbolType === 'struct' ||
+        symbolType === 'union' ||
+        symbolType === 'exception' ||
+        symbolType === 'enum' ||
+        symbolType === 'service' ||
+        symbolType === 'interaction' ||
+        symbolType === 'typedef' ||
+        symbolType === 'namespace';
+}
+
+function isSymbolTypeDeclaration(node: nodes.ThriftNode, symbolType: string): boolean {
+    switch (symbolType) {
+        case 'field':
+            return node.type === nodes.ThriftNodeType.Field;
+        case 'method':
+            return node.type === nodes.ThriftNodeType.Function;
+        case 'enumValue':
+            return node.type === nodes.ThriftNodeType.EnumMember;
+        default:
+            return false;
+    }
 }

--- a/tests/src/definition-provider/test-definition-provider.js
+++ b/tests/src/definition-provider/test-definition-provider.js
@@ -219,6 +219,35 @@ service UserService {
         assert.strictEqual(methodDefinition.range.start.line, 5, 'Method definition should be the later declaration');
     });
 
+    it('should ignore previous method and enum member names when resolving a type reference', async () => {
+        const text = `service Earlier {
+    void Status()
+}
+
+enum Other {
+    Status = 1
+}
+
+struct Later {
+    1: required Status status
+}
+
+enum Status {
+    ACTIVE = 1
+}`;
+        const document = createMockDocument(text);
+        const position = createMockPosition(9, 18); // On "Status" type in Later
+
+        const definition = await provider.provideDefinition(
+            document,
+            position,
+            createMockCancellationToken()
+        );
+
+        assert(definition, 'Should find definition for Status enum type');
+        assert.strictEqual(definition.range.start.line, 12, 'Enum definition should be at line 12');
+    });
+
     it('should find definition of enum type', async () => {
         const enumText = `enum Status {
     ACTIVE = 1,

--- a/tests/src/document-highlight-provider/test-document-highlight-provider.js
+++ b/tests/src/document-highlight-provider/test-document-highlight-provider.js
@@ -144,6 +144,37 @@ describe('document-highlight-provider', () => {
         assert.ok(reads.length >= 1);
     });
 
+    it('provider does not mix type highlights when cursor is on a same-named field', () => {
+        const text = [
+            'struct User {',
+            '  1: string name',
+            '}',
+            '',
+            'struct Container {',
+            '  1: User User',
+            '}'
+        ].join('\n');
+        const doc = createDoc(text);
+        const provider = new ThriftDocumentHighlightProvider();
+        const result = provider.provideDocumentHighlights(doc, {line: 5, character: 12}, {isCancellationRequested: false});
+        const arr = Array.isArray(result) ? result : [];
+
+        assert.deepStrictEqual(
+            arr.map(h => ({
+                line: h.range.start.line,
+                character: h.range.start.character,
+                text: doc.getText(h.range),
+                kind: h.kind
+            })),
+            [{
+                line: 5,
+                character: 10,
+                text: 'User',
+                kind: vscode.DocumentHighlightKind.Write
+            }]
+        );
+    });
+
     it('provider returns empty array on cancellation', () => {
         const provider = new ThriftDocumentHighlightProvider();
         const doc = createDoc('struct A {\n  1: i32 id\n}');

--- a/tests/src/references/test-references-provider-functionality.js
+++ b/tests/src/references/test-references-provider-functionality.js
@@ -61,6 +61,21 @@ function createMockDocument(text, fileName = 'test.thrift') {
 }
 
 describe('references-provider-functionality', () => {
+    let originalFindFiles;
+
+    before(() => {
+        originalFindFiles = vscode.workspace.findFiles;
+        vscode.workspace.findFiles = async () => [];
+    });
+
+    after(() => {
+        vscode.workspace.findFiles = originalFindFiles;
+    });
+
+    function getRangeText(document, range) {
+        return document.getText(range);
+    }
+
     it('should find references correctly', async () => {
         const provider = new ThriftReferencesProvider();
 
@@ -91,5 +106,71 @@ service UserService {
         );
 
         assert(Array.isArray(excludeReferences), 'References should be an array');
+    });
+
+    it('keeps includeDeclaration-specific reference cache entries separate', async () => {
+        const provider = new ThriftReferencesProvider();
+
+        const testDocument = createMockDocument(`struct User {
+  1: required i32 id
+}
+
+service UserService {
+  User getUser()
+}`);
+
+        const userPosition = new vscode.Position(0, 7);
+        const excludeReferences = await provider.provideReferences(
+            testDocument,
+            userPosition,
+            {includeDeclaration: false},
+            {isCancellationRequested: false}
+        );
+        const includeReferences = await provider.provideReferences(
+            testDocument,
+            userPosition,
+            {includeDeclaration: true},
+            {isCancellationRequested: false}
+        );
+
+        assert.strictEqual(
+            excludeReferences.some(ref => ref.range.start.line === 0),
+            false,
+            'includeDeclaration=false should omit the struct declaration'
+        );
+        assert.strictEqual(
+            includeReferences.some(ref => ref.range.start.line === 0),
+            true,
+            'includeDeclaration=true should include the struct declaration even after an exclude lookup'
+        );
+    });
+
+    it('does not treat type definitions or type references as field-name references', async () => {
+        const provider = new ThriftReferencesProvider();
+
+        const testDocument = createMockDocument(`struct User {
+  1: required string name
+}
+
+struct Container {
+  1: required User User
+}`);
+
+        const fieldNamePosition = new vscode.Position(5, 20); // On the field name "User"
+        const references = await provider.provideReferences(
+            testDocument,
+            fieldNamePosition,
+            {includeDeclaration: true},
+            {isCancellationRequested: false}
+        );
+
+        assert.deepStrictEqual(
+            references.map(ref => ({
+                line: ref.range.start.line,
+                text: getRangeText(testDocument, ref.range)
+            })),
+            [{line: 5, text: 'User'}],
+            'field references should only include the field name declaration'
+        );
     });
 });

--- a/tests/src/rename-provider/test-rename-provider-regression.js
+++ b/tests/src/rename-provider/test-rename-provider-regression.js
@@ -114,6 +114,47 @@ describe('rename-provider-regression', () => {
         await run();
     });
 
+    it('does not rename a type when renaming a same-named field', async () => {
+        const filePath = path.join(__dirname, 'test-files', 'field-type-collision.thrift');
+        const content = [
+            'struct User {',
+            '  1: string name,',
+            '}',
+            '',
+            'struct Container {',
+            '  1: User User,',
+            '}'
+        ].join('\n');
+        const doc = createMockDocument(content, filePath);
+        doc.uri.toString = () => filePath;
+
+        mockVscode.workspace = {
+            findFiles: async () => [],
+            textDocuments: [doc],
+            openTextDocument: async (uri) => {
+                if (uri && uri.fsPath === filePath) {
+                    return doc;
+                }
+                throw new Error('Unexpected document request');
+            }
+        };
+
+        const provider = new ThriftRenameProvider();
+        const edit = await provider.provideRenameEdits(
+            doc,
+            new Position(5, 12), // On the field name "User", not the field type
+            'owner',
+            {isCancellationRequested: false}
+        );
+
+        assert.ok(edit, 'Expected a WorkspaceEdit');
+        const newText = applyEditsToContent(content, edit.edits || []);
+
+        assert.ok(newText.includes('struct User {'), 'Type declaration should remain unchanged');
+        assert.ok(newText.includes('  1: User owner,'), 'Only the field name should be renamed');
+        assert.strictEqual((newText.match(/\bowner\b/g) || []).length, 1, 'Only one field-name edit is expected');
+    });
+
     it('passes injected dependencies into the references provider for cross-file rename edits', async () => {
         const sourcePath = path.join(__dirname, 'test-files', 'source.thrift');
         const targetPath = path.join(__dirname, 'test-files', 'target.thrift');

--- a/tests/src/rename-provider/test-rename-provider.js
+++ b/tests/src/rename-provider/test-rename-provider.js
@@ -1,11 +1,13 @@
 // RenameProvider unit tests with a minimal VSCode mock
 const assert = require('assert');
 const vscode = require('vscode');
-const {ThriftRenameProvider} = require('../../../out/rename-provider.js');
 
 // Mock the references provider to return simple results
 const referencesProvider = require('../../../out/references-provider.js');
 const originalThriftReferencesProvider = referencesProvider.ThriftReferencesProvider;
+const renameProviderPath = require.resolve('../../../out/rename-provider.js');
+const originalRenameProviderModule = require.cache[renameProviderPath];
+let ThriftRenameProvider;
 
 // Create a simple mock that doesn't require full AST parsing
 class MockThriftReferencesProvider {
@@ -38,9 +40,6 @@ class MockThriftReferencesProvider {
         return references;
     }
 }
-
-// Replace the references provider with our mock
-referencesProvider.ThriftReferencesProvider = MockThriftReferencesProvider;
 
 function createMockDocument(content) {
     const lines = content.split('\n');
@@ -140,8 +139,18 @@ function run() {
 }
 
 describe('rename-provider', () => {
+    before(() => {
+        referencesProvider.ThriftReferencesProvider = MockThriftReferencesProvider;
+        delete require.cache[renameProviderPath];
+        ({ThriftRenameProvider} = require('../../../out/rename-provider.js'));
+    });
+
     after(() => {
         referencesProvider.ThriftReferencesProvider = originalThriftReferencesProvider;
+        delete require.cache[renameProviderPath];
+        if (originalRenameProviderModule) {
+            require.cache[renameProviderPath] = originalRenameProviderModule;
+        }
     });
 
     it('should pass all test assertions', async () => {


### PR DESCRIPTION
## Summary
- use resolved symbol kinds when searching references so fields, methods, enum values, and types do not collide by name
- separate references cache entries by includeDeclaration and current document text
- filter document highlights by cursor symbol kind
- prevent current-document definition lookup from treating same-named methods or enum members as type definitions
- scope rename-provider test monkey patching to its suite lifecycle

## Tests
- pnpm run lint:fix
- pnpm run lint
- pnpm run build
- pnpm test (1171 passing)
- git diff --check