### PR TITLE
docs(harness): add project harness validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
         run: pnpm run perf:benchmark -- --iterations 5
 
       - name: Performance assertions (multi-size)
-        run: pnpm exec mocha --require tests/require-hook.js --timeout 120000 tests/perf/perf-assertions.js
+        run: pnpm run perf:assertions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ When possible, use subagents for independent scans or validation so the main thr
 - `tests/src/`: canonical Mocha tests for core and extension behavior.
 - `tests/cli/`: CLI tests.
 - `tests/perf/`: performance benchmark and threshold scripts.
+- `tests/scenarios/`: scenario-oriented multi-file or user-journey checks before or alongside canonical tests.
 - `tests/debug/`: manual reproduction, analysis, and migration helper scripts. These are not default release gates.
 - `out/`, `dist/`, package-local `out/` / `dist/`, `coverage/`, and `tmp/` are generated outputs.
 
@@ -34,12 +35,14 @@ When possible, use subagents for independent scans or validation so the main thr
 | --- | --- |
 | `npm run lint:fix` | ESLint autofix for `packages/*/src/**/*.ts`; required after code changes |
 | `npm run lint` | ESLint flat config over package source |
+| `npm run harness:check` | Verifies required agent docs, version anchors, workflow Node version, and local Markdown links |
 | `npm run build` | clean, build core, compile VS Code package, bundle extension |
 | `npm run build:cli` | bundle and compile CLI package |
 | `npm test` | build extension + CLI, then run Mocha |
 | `npm run test:single -- <file>` | build extension + CLI, then run one Mocha file |
 | `npm run coverage:cli` | CLI-focused coverage |
 | `npm run perf:benchmark` | parser/formatter/diagnostics/cache/indexing performance benchmark |
+| `npm run perf:assertions` | CI-aligned multi-size parser/formatter performance assertions |
 | `npm run smoke:package` | VSIX and CLI tarball smoke checks |
 
 ## Conventions And Gotchas
@@ -59,7 +62,7 @@ When possible, use subagents for independent scans or validation so the main thr
 
 - Tests use Mocha `describe` / `it`, timeout 30s.
 - Import compiled output from `../../../out/...`; `tests/require-hook.js` remaps package paths.
-- Do not manually mock `vscode` or override `Module.prototype.require`; `.mocharc.json` loads the shared require hook.
+- Use the shared `vscode` require hook by default. Only use `createVscodeMock()` / `installVscodeMock()` for the documented custom mock cases in [tests/TESTING.md](tests/TESTING.md); never override `Module.prototype.require`.
 - Keep all `require` calls at file top level.
 - Promote long-lived manual reproductions from `tests/debug/**` or `tests/scenarios/**` into `tests/src/**` before treating them as CI guarantees.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-本文档描述 Thrift Support 扩展的核心机制：缓存系统、增量解析/格式化与并发控制。
+本文档描述 Thrift Support 的包级数据流，以及 VS Code 扩展运行时的缓存系统、增量解析/格式化与并发控制。
 
 ---
 
@@ -17,6 +17,28 @@
 ---
 
 ## 整体结构
+
+### 包级数据流
+
+```
+packages/core/src
+  ├─ parser / tokenizer / formatter / diagnostics / refactor primitives
+  ├─ shared config normalization
+  └─ cache, memory, error, and performance utilities
+
+packages/cli/src      -> packages/core/src
+packages/vscode/src   -> packages/core/src + VS Code API
+tests                 -> compiled root out/ and package outputs via tests/require-hook.js
+```
+
+边界规则：
+
+- `packages/core/src/` 不依赖 VS Code API；共享语言语义、格式化、诊断规则和配置归一化应放在 core。
+- `packages/vscode/src/` 负责 provider 生命周期、命令注册、工作区索引、编辑器范围处理和 VS Code 配置桥接。
+- `packages/cli/src/` 负责 CLI 参数、终端输出和配置加载；语言行为应调用 core。
+- 新增跨包共享行为时，优先在 core 建模，再由 VS Code 与 CLI 层分别适配输入输出。
+
+### VS Code 运行时
 
 ```
 extension.ts

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,9 +5,9 @@
 ## 版本要求（务必统一）
 
 - Node.js: 24.x LTS（推荐 24.16.0，与 `.nvmrc` / `.node-version` 一致）
-- pnpm: 10.25.0（由 package.json 的 packageManager 固定）
+- pnpm: 11.5.0（由 package.json 的 packageManager 固定）
 - VS Code 引擎: ^1.75.0（与 package.json engines.vscode 一致）
-- TypeScript: ^5.6.0（与 devDependencies 一致）
+- TypeScript: ^5.9.3（与 devDependencies 一致）
 - @vscode/vsce: ^3.9.1（用于本地打包/发布）
 
 提示：如本地 Node 版本不同，可能导致安装或构建失败（如 undici 要求 Node >= 20.18.1）。建议使用 nvm-windows/Volta 等工具固定
@@ -330,8 +330,8 @@ tests/src/
 # 运行所有测试
 npm test
 
-# 运行特定测试文件
-node tests/src/formatter/test-text-utils.js
+# 运行特定测试文件（会先构建 extension + CLI）
+npm run test:single -- tests/src/formatter/test-text-utils.js --exit
 
 # 生成覆盖率报告
 npm run coverage
@@ -391,6 +391,9 @@ npm run watch
 # 运行主要测试
 npm test -- --exit
 
+# 校验 agent/harness 入口文档、版本锚点和本地链接
+npm run harness:check
+
 # 运行单个测试文件
 npm run test:single
 
@@ -402,6 +405,9 @@ npm run coverage:cli
 
 # 性能基准
 npm run perf:benchmark
+
+# 性能门槛断言（与 CI 对齐）
+npm run perf:assertions
 
 # 机器可读性能结果（JSON）
 npm run perf:benchmark:json
@@ -422,7 +428,8 @@ npm run smoke:package
 
 ## 手动测试与历史脚本
 
-- 默认测试契约是 `npm test -- --exit`、`npm run coverage:cli`、`npm run perf:benchmark` 和 `npm run smoke:package`。
+- 默认测试契约是 `npm test -- --exit`、`npm run coverage`、`npm run coverage:cli`、`npm run perf:benchmark`、`npm run perf:assertions` 和 `npm run smoke:package`。
+- CI 还包含 CLI dogfood：`node packages/cli/dist/cli.js --version`、`format --check`、`lint`、`symbols`，目标文件为 `test-files/example-enum.thrift`。
 - `tests/src/**/*.js` 是规范 Mocha 测试；`tests/cli/**/*.js` 覆盖 CLI；`tests/perf/**/*.js` 覆盖性能门槛。
 - `tests/debug/**` 下的脚本只用于手动复现、排障或一次性分析，不是 release gate；历史根目录手动脚本已归档到 `tests/debug/manual/**`。
 - 如果某个历史脚本仍在验证长期行为，应先迁移为 `tests/src/**` 下的 Mocha 测试，再删除或归档原脚本。
@@ -436,9 +443,9 @@ npm run smoke:package
     - 作用：根据 Conventional Commits 生成/更新 Release PR；合并后创建 Git Tag + GitHub Release
 
 - publish（.github/workflows/publish.yml）
-    - 触发：GitHub Release 发布（released: published）、或手动触发（workflow_dispatch）
-    - 作用：安装依赖 → 构建 → 打包 VSIX →（可选）上传到 GitHub Release → 发布到 VS Code Marketplace 与 Open VSX
-    - 凭据：VSCE_PAT（Marketplace）、OVSX_PAT（Open VSX），以及内置 GITHUB_TOKEN（上传 Release 附件）
+    - 触发：GitHub Release 发布（release: published）；仅处理 `thrift-support-v*` 根扩展 release
+    - 作用：安装依赖 → 构建 → 打包 VSIX → 上传到 GitHub Release → 发布到 VS Code Marketplace、Open VSX 与 npm CLI 包
+    - 凭据：VSCE_PAT（Marketplace）、OVSX_PAT（Open VSX）、npm OIDC trusted publishing，以及内置 GITHUB_TOKEN（上传 Release 附件）
 
 建议流程：功能分支开发 → 合并到 master → 等待/审阅 release-please 生成的 Release PR → 合并 Release PR → 触发 publish
 自动发布。
@@ -464,6 +471,7 @@ npm run smoke:package
 1) 确保本地环境一致（Node 24.x LTS，推荐 24.16.0），安装依赖并通过所有检查：
     - corepack enable
     - pnpm install
+    - npm run harness:check
     - npm run lint
     - npm run build
     - npm test -- --exit
@@ -475,7 +483,7 @@ npm run smoke:package
 4) 等待 release-please 生成/更新 Release PR：
     - 在该 PR 中再次审阅 CHANGELOG（可继续微调用语/结构）
     - 合并 Release PR 后将自动创建 Tag 与 GitHub Release
-5) 发布流水线（publish.yml）将自动构建并发布到 VS Marketplace 与 Open VSX。
+5) 发布流水线（publish.yml）将自动构建并发布到 VS Marketplace、Open VSX 与 npm CLI 包。
 
 ### 快速命令（本地辅助）
 

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -60,14 +60,15 @@ Rules:
 | VS Code provider/command/formatting bridge | `npm run lint:fix`, `npm run build`, relevant `tests/src/<provider-or-bridge>`, usually `npm test` |
 | CLI behavior | `npm run build:cli`, relevant `tests/cli/**`, `npm run coverage:cli` for user-visible CLI changes |
 | TextMate grammar | grammar tokenization tests in `tests/src/test-grammar-tokenization.js` |
-| Performance-sensitive paths | `npm run perf:benchmark` |
-| Packaging/release files | `npm run smoke:package` or the narrower smoke command |
-| Docs-only maps and README links | JSON/link/name scans plus relevant package smoke configuration test when package files change |
+| Performance-sensitive paths | `npm run perf:benchmark`, `npm run perf:assertions` for CI threshold parity |
+| Packaging/release files | `npm run smoke:package`, or `npm run smoke:package:vsix` / `npm run smoke:package:cli` for narrower package checks |
+| Docs-only maps, README links, and version anchors | `npm run harness:check` |
 
 ## Harness Maintenance
 
 - Keep `AGENTS.md` as a short map, not an encyclopedia.
 - Link durable knowledge from [docs/README.md](README.md).
+- Run `npm run harness:check` after changing agent entry docs, local Markdown links, Node/pnpm version anchors, or workflow Node setup.
 - Move repeated review comments into docs, tests, lints, or scripts.
 - Promote stable manual reproductions from `tests/debug/**` into canonical Mocha tests under `tests/src/**`.
 - Re-check this map when adding a new top-level directory, package, test class, generated output, or delivery gate.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,5 @@ Use this page as the repository-local map for agent and contributor documentatio
 ## Feedback Loop
 
 When a review comment, incident, or repeated bug reveals hidden project knowledge, promote it into one of these docs, a test, a lint, or a script. Prefer executable checks for invariants that must not drift.
+
+Run `npm run harness:check` after changing agent entry docs, local Markdown links, Node/pnpm version anchors, or workflow Node setup.

--- a/package.json
+++ b/package.json
@@ -270,6 +270,7 @@
     "watch:bundle": "node build.js --watch",
     "lint": "eslint --cache 'packages/*/src/**/*.ts'",
     "lint:fix": "eslint --cache 'packages/*/src/**/*.ts' --fix",
+    "harness:check": "node scripts/check-harness-docs.js",
     "build:core": "pnpm --filter @tanzz/thrift-core run build",
     "build:cli": "node packages/cli/build.js && tsc -p packages/cli/tsconfig.json",
     "clean": "rimraf out dist",
@@ -285,6 +286,7 @@
     "coverage": "pnpm run build && pnpm run build:cli && c8 --reporter text-summary --reporter lcov mocha",
     "coverage:cli": "pnpm --filter @tanzz/thrift-core run build && node packages/cli/build.js && pnpm exec tsc -p packages/cli/tsconfig.json && c8 --exclude 'packages/core/**' --exclude-after-remap --reporter text-summary --reporter lcov mocha --no-config --timeout 30000 tests/cli/test-cli-integration.js tests/cli/test-cli-units.js",
     "perf:benchmark": "node tests/perf/run-performance-benchmark.js",
+    "perf:assertions": "pnpm exec mocha --require tests/require-hook.js --timeout 120000 tests/perf/perf-assertions.js",
     "perf:benchmark:json": "node tests/perf/run-performance-benchmark.js --json"
   },
   "devDependencies": {

--- a/scripts/check-harness-docs.js
+++ b/scripts/check-harness-docs.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const failures = [];
+
+function read(relativePath) {
+    return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function exists(relativePath) {
+    return fs.existsSync(path.join(root, relativePath));
+}
+
+function expect(condition, message) {
+    if (!condition) {
+        failures.push(message);
+    }
+}
+
+function isExternalLink(target) {
+    return /^(https?:|mailto:)/.test(target);
+}
+
+function normalizeLinkTarget(target) {
+    const withoutAnchor = target.split("#")[0];
+    return withoutAnchor.replace(/^<|>$/g, "");
+}
+
+function checkMarkdownLinks(relativePath) {
+    const source = read(relativePath);
+    const baseDir = path.dirname(path.join(root, relativePath));
+    const linkPattern = /!?\[[^\]]*]\(([^)]+)\)/g;
+    let match;
+
+    while ((match = linkPattern.exec(source)) !== null) {
+        const rawTarget = match[1].trim();
+        const target = normalizeLinkTarget(rawTarget);
+
+        if (!target || target.startsWith("#") || isExternalLink(target)) {
+            continue;
+        }
+
+        const resolved = path.resolve(baseDir, target);
+        expect(
+            resolved.startsWith(root) && fs.existsSync(resolved),
+            `${relativePath} links to missing local target: ${rawTarget}`
+        );
+    }
+}
+
+const packageJson = JSON.parse(read("package.json"));
+const packageManager = packageJson.packageManager || "";
+const pnpmMatch = packageManager.match(/^pnpm@(.+)$/);
+const nodeVersion = read(".nvmrc").trim();
+const nodeMajor = nodeVersion.split(".")[0];
+const developmentGuide = read("DEVELOPMENT.md");
+
+expect(pnpmMatch, "package.json packageManager must pin pnpm, for example pnpm@11.5.0");
+if (pnpmMatch) {
+    expect(
+        developmentGuide.includes(`pnpm: ${pnpmMatch[1]}`),
+        `DEVELOPMENT.md must mention pnpm: ${pnpmMatch[1]} from package.json packageManager`
+    );
+}
+
+expect(
+    developmentGuide.includes(`TypeScript: ${packageJson.devDependencies.typescript}`),
+    `DEVELOPMENT.md must mention TypeScript: ${packageJson.devDependencies.typescript} from package.json devDependencies`
+);
+expect(
+    developmentGuide.includes(`@vscode/vsce: ${packageJson.devDependencies["@vscode/vsce"]}`),
+    `DEVELOPMENT.md must mention @vscode/vsce: ${packageJson.devDependencies["@vscode/vsce"]} from package.json devDependencies`
+);
+
+expect(read(".node-version").trim() === nodeVersion, ".nvmrc and .node-version must match");
+expect(
+    packageJson.engines && packageJson.engines.node === `>=${nodeMajor} <${Number(nodeMajor) + 1}`,
+    `package.json engines.node must match Node ${nodeMajor}.x from .nvmrc`
+);
+expect(
+    developmentGuide.includes(`Node.js: ${nodeMajor}.x`) && developmentGuide.includes(nodeVersion),
+    `DEVELOPMENT.md must mention Node.js ${nodeMajor}.x and recommended ${nodeVersion}`
+);
+
+for (const workflowName of fs.readdirSync(path.join(root, ".github", "workflows"))) {
+    if (!workflowName.endsWith(".yml") && !workflowName.endsWith(".yaml")) {
+        continue;
+    }
+
+    const workflowPath = path.join(".github", "workflows", workflowName);
+    const workflow = read(workflowPath);
+    if (workflow.includes("actions/setup-node")) {
+        expect(
+            workflow.includes(`node-version: ${nodeMajor}.x`),
+            `${workflowPath} must use node-version: ${nodeMajor}.x`
+        );
+    }
+}
+
+for (const requiredPath of [
+    "AGENTS.md",
+    "docs/PROJECT_MAP.md",
+    "docs/README.md",
+    "ARCHITECTURE.md",
+    "DEVELOPMENT.md",
+    "tests/README.md",
+    "tests/TESTING.md",
+    "tests/debug/README.md"
+]) {
+    expect(exists(requiredPath), `Missing required harness file: ${requiredPath}`);
+}
+
+for (const markdownPath of [
+    "AGENTS.md",
+    "README.md",
+    "README.zh-CN.md",
+    "ARCHITECTURE.md",
+    "DEVELOPMENT.md",
+    "docs/PROJECT_MAP.md",
+    "docs/README.md",
+    "tests/README.md",
+    "tests/TESTING.md",
+    "tests/debug/README.md"
+]) {
+    checkMarkdownLinks(markdownPath);
+}
+
+if (failures.length > 0) {
+    console.error("Harness documentation check failed:");
+    for (const failure of failures) {
+        console.error(`- ${failure}`);
+    }
+    process.exit(1);
+}
+
+console.log("Harness documentation check passed.");

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -468,11 +468,11 @@ describe('workspace-symbol-provider', () => {
 ### 运行单个测试文件
 
 ```bash
-# 直接运行
-node tests/src/formatter/test-text-utils.js
+# 推荐：使用仓库脚本，保持 build 和 Mocha 配置一致
+npm run test:single -- tests/src/formatter/test-text-utils.js --exit
 
-# 或使用 Mocha
-npx mocha tests/src/formatter/test-text-utils.js
+# 已手动构建且只需重跑 Mocha 时
+pnpm exec mocha --config .mocharc.single.json tests/src/formatter/test-text-utils.js --exit
 ```
 
 ### 使用调试器


### PR DESCRIPTION
## Summary
- add npm run harness:check for agent docs, version anchors, workflow Node setup, and local Markdown links
- document CI parity, publish gates, package data-flow boundaries, and test command entry points
- expose perf assertions as npm run perf:assertions and use it from CI

## Verification
- npm run harness:check
- git diff --check

Full build/test was not run because this is a harness/docs/CI-entry update and the worktree had no compiled out/ artifacts.