### PR TITLE
feat(cli): add --range partial formatting to format command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Thrift Support for VSCode
+# Thrift Support for VS Code and CLI
 
 [English](./README.md) | [简体中文](./README.zh-CN.md)
 
-Apache Thrift language intelligence for VS Code: syntax highlighting, formatter, diagnostics, navigation, completion, rename/refactor, a CI-ready CLI, and performance gates.
+Apache Thrift IDL tooling built on one shared language core, delivered through a VS Code extension for interactive development and a CLI for automation and CI/CD.
 
 [![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/tanzz.thrift-support?label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=tanzz.thrift-support)
 [![Installs](https://img.shields.io/visual-studio-marketplace/i/tanzz.thrift-support?label=Installs)](https://marketplace.visualstudio.com/items?itemName=tanzz.thrift-support)
@@ -16,7 +16,16 @@ Apache Thrift language intelligence for VS Code: syntax highlighting, formatter,
 > For development details, see [DEVELOPMENT.md](DEVELOPMENT.md).
 > For configuration keys, see [docs/settings-reference.md](docs/settings-reference.md). For supported versions and vulnerability reporting, see [SECURITY.md](SECURITY.md).
 
-## 🚀 Features
+## Choose Your Interface
+
+| Interface | Best for | Main capabilities | Install |
+|-----------|----------|-------------------|---------|
+| **VS Code extension** | Interactive authoring and review | Highlighting, completion, diagnostics, navigation, formatting, rename, refactors, and hierarchy views | Search for **Thrift Support** in VS Code, or install from [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=tanzz.thrift-support) / [Open VSX](https://open-vsx.org/extension/tanzz/thrift-support) |
+| **`thrift-support` CLI** | CI/CD, pre-commit checks, scripts, and editor-independent workflows | Whole-file and line-range formatting, diagnostics, AST output, and symbol listing | `npm install --save-dev thrift-support` |
+
+Both interfaces reuse `@tanzz/thrift-core` for Thrift parsing and language behavior. In particular, VS Code **Format Selection** and CLI `format --range` share the same formatting-context logic.
+
+## 🚀 VS Code Extension
 
 ### Syntax Highlighting
 
@@ -30,8 +39,6 @@ Apache Thrift language intelligence for VS Code: syntax highlighting, formatter,
 - Selection formatting: format only the selected text
 - Smart alignment: align field types, field names, and comments
 - Configurable: indentation, line length, and more formatting rules
-
-> Publisher namespace: tanzz (used for both VS Marketplace and Open VSX)
 
 ### Code Navigation
 
@@ -81,7 +88,7 @@ See [advanced features](docs/advanced-features.md) for details about stream, sin
 
 ## 🖥️ CLI Tool
 
-In addition to the VS Code extension, a standalone npm CLI tool `thrift-support` is available for use in CI/CD pipelines or the command line.
+The standalone npm package `thrift-support` exposes the shared Thrift engine to CI/CD pipelines, pre-commit hooks, shell scripts, and other editors. See the [complete CLI reference](https://github.com/tzzs/vsce-thrift-support/blob/master/packages/cli/README.md) for every option.
 
 ### Install
 
@@ -100,8 +107,16 @@ thrift-support format --check src/**/*.thrift
 # Format and write back to files
 thrift-support format --write src/
 
+# Format only lines 12 through 18 (1-based, inclusive)
+thrift-support format --range 12:18 src/example.thrift
+
+# Check or write only that range
+thrift-support format --check --range 12:18 src/example.thrift
+thrift-support format --write --range 12:18 src/example.thrift
+
 # Read from stdin and output to stdout
 echo "struct Foo{1:i32 id}" | thrift-support format --stdin
+echo "struct Foo{1:i32 id}" | thrift-support format --stdin --range 1:1
 
 # Run diagnostics (syntax + semantic rules)
 thrift-support lint src/**/*.thrift
@@ -113,6 +128,8 @@ thrift-support parse --stdin < myfile.thrift
 # List defined symbols
 thrift-support symbols --json src/my.thrift
 ```
+
+`--range` changes only the selected lines; indentation context is derived from the preceding lines. This matches the extension's **Format Selection** behavior because both paths call the shared core implementation.
 
 ### Configuration
 
@@ -141,14 +158,12 @@ Create a `.thriftrc.json` in your project root; the CLI searches upward automati
 | 2 | Usage error |
 | 3 | Internal error |
 
-## 📦 Installation
+## 📦 Install the VS Code Extension
 
-1. Open VSCode
+1. Open VS Code
 2. Open the Extensions view (`Ctrl+Shift+X`)
 3. Search for "Thrift Support"
 4. Click Install
-
-## 🔧 Usage
 
 ## 🧭 Project Structure
 
@@ -165,6 +180,8 @@ For a fuller agent-readable directory map and validation matrix, see [docs/PROJE
 - `test-files/` / `tests/src/**/test-files/`: fixtures
 - `language-configuration.json`: VS Code bracket, comment, and language configuration
 
+## 🔧 VS Code Extension Usage
+
 ### Formatting
 
 - Format Document: `Ctrl+Shift+I` (Windows/Linux) or `Cmd+Shift+I` (macOS)
@@ -172,12 +189,8 @@ For a fuller agent-readable directory map and validation matrix, see [docs/PROJE
 - Command Palette:
     - `Thrift: Format Document`
     - `Thrift: Format Selection`
-    - `Thrift: Extract Type (typedef)`
-    - `Thrift: Move Type to File...`
-    - `Thrift: Show Performance Report`
-    - `Thrift: Clear Performance Data`
-    - `Thrift: Show Memory Report`
-    - `Thrift: Force Garbage Collection`
+
+Selection formatting and CLI `format --range` use the same core formatting-context implementation; use the editor command interactively and the CLI form in automation.
 
 ### Code Navigation
 
@@ -206,7 +219,7 @@ For a fuller agent-readable directory map and validation matrix, see [docs/PROJE
     - Ignore '=' inside field annotations so it won’t be treated as the start of a default value
     - set<T> default values accept either `[]` or `{}` with bracket-aware element checks
 
-Note: Diagnostics update in real-time during editing and on save. You can review them in VSCode’s “Problems” panel.
+Note: Diagnostics update in real-time during editing and on save. You can review them in VS Code’s “Problems” panel.
 
 ### Code Refactoring
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-# Thrift Support for VSCode
+# Thrift Support for VS Code 与 CLI
 
 [English](./README.md) | [简体中文](./README.zh-CN.md)
 
@@ -9,14 +9,23 @@
 [![CI](https://github.com/tzzs/vsce-thrift-support/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/tzzs/vsce-thrift-support/actions/workflows/ci.yml)
 [![Publish](https://github.com/tzzs/vsce-thrift-support/actions/workflows/publish.yml/badge.svg)](https://github.com/tzzs/vsce-thrift-support/actions/workflows/publish.yml)
 
-一个面向 Apache Thrift IDL 的 VS Code 语言智能扩展，覆盖语法高亮、格式化、诊断、导航、补全、重命名/重构、CI 可用 CLI 与性能门禁。
+一套基于共享语言核心构建的 Apache Thrift IDL 工具：VS Code 扩展负责交互式开发体验，CLI 负责自动化、脚本与 CI/CD。
 
 ![Thrift 诊断与格式化预览](docs/assets/marketplace/format-diagnostics.png)
 
 > 开发者请阅读开发指南：见仓库根目录的 [DEVELOPMENT.md](DEVELOPMENT.md)。
 > 配置项详见 [docs/settings-reference.md](docs/settings-reference.md)，安全支持范围与漏洞报告详见 [SECURITY.md](SECURITY.md)。
 
-## 🚀 功能特性
+## 选择使用入口
+
+| 入口 | 适用场景 | 主要能力 | 安装方式 |
+|------|----------|----------|----------|
+| **VS Code 扩展** | 交互式编写、浏览与评审 | 高亮、补全、诊断、导航、格式化、重命名、重构与层级视图 | 在 VS Code 中搜索 **Thrift Support**，或通过 [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=tanzz.thrift-support) / [Open VSX](https://open-vsx.org/extension/tanzz/thrift-support) 安装 |
+| **`thrift-support` CLI** | CI/CD、提交前检查、脚本及独立于编辑器的工作流 | 整文件/行范围格式化、诊断、AST 输出与符号列表 | `npm install --save-dev thrift-support` |
+
+两个入口都复用 `@tanzz/thrift-core` 的 Thrift 解析与语言行为。其中，VS Code 的**格式化选择**与 CLI 的 `format --range` 使用同一套格式化上下文逻辑。
+
+## 🚀 VS Code 扩展
 
 ### 语法高亮
 
@@ -78,7 +87,7 @@
 
 ## 🖥️ CLI 工具
 
-除 VS Code 扩展外，本项目同时提供独立的 npm CLI 工具 `thrift-support`，可在 CI/CD 或命令行中使用。
+独立 npm 包 `thrift-support` 将共享 Thrift 引擎提供给 CI/CD、提交前检查、Shell 脚本及其他编辑器。完整参数见 [CLI 使用文档](https://github.com/tzzs/vsce-thrift-support/blob/master/packages/cli/README.md)。
 
 ### 安装
 
@@ -97,8 +106,16 @@ thrift-support format --check src/**/*.thrift
 # 格式化并写回文件
 thrift-support format --write src/
 
+# 仅格式化第 12 至 18 行（从 1 开始，包含首尾）
+thrift-support format --range 12:18 src/example.thrift
+
+# 仅检查或写回该范围
+thrift-support format --check --range 12:18 src/example.thrift
+thrift-support format --write --range 12:18 src/example.thrift
+
 # 从 stdin 读取并输出
 echo "struct Foo{1:i32 id}" | thrift-support format --stdin
+echo "struct Foo{1:i32 id}" | thrift-support format --stdin --range 1:1
 
 # 运行诊断（语法 + 语义规则）
 thrift-support lint src/**/*.thrift
@@ -110,6 +127,8 @@ thrift-support parse --stdin < myfile.thrift
 # 列出定义的符号
 thrift-support symbols --json src/my.thrift
 ```
+
+`--range` 只修改选中的行，缩进上下文从范围之前的内容推导。由于两个入口调用同一套 core 实现，其行为与扩展的**格式化选择**一致。
 
 ### 配置文件
 
@@ -138,14 +157,12 @@ thrift-support symbols --json src/my.thrift
 | 2 | 用法错误 |
 | 3 | 内部错误 |
 
-## 📦 安装
+## 📦 安装 VS Code 扩展
 
-1. 打开 VSCode
+1. 打开 VS Code
 2. 进入扩展市场 (`Ctrl+Shift+X`)
 3. 搜索 "Thrift Support"
 4. 点击安装
-
-## 🔧 使用方法
 
 ## 🧭 项目结构
 
@@ -162,6 +179,8 @@ thrift-support symbols --json src/my.thrift
 - `test-files/` / `tests/src/**/test-files/`: 测试夹具
 - `language-configuration.json`: VS Code 语言括号、注释等配置
 
+## 🔧 VS Code 扩展使用方法
+
 ### 格式化代码
 
 - **格式化文档**：`Ctrl+Shift+I` (Windows/Linux) 或 `Cmd+Shift+I` (Mac)
@@ -170,7 +189,7 @@ thrift-support symbols --json src/my.thrift
     - `Thrift: Format Document`
     - `Thrift: Format Selection`
 
-> 发布命名空间：`tanzz`（VS Marketplace 与 Open VSX 均使用此命名空间）
+扩展的格式化选择与 CLI `format --range` 使用同一套 core 格式化上下文实现：交互编辑使用扩展命令，自动化场景使用 CLI。
 
 ### 代码导航
 
@@ -199,7 +218,7 @@ thrift-support symbols --json src/my.thrift
     - 忽略字段注解中的 '='，避免被误识别为默认值起始
     - set<T> 默认值同时接受 `[]` 或 `{}` 包裹，并依据顶层括号进行元素分隔校验
 
-说明：诊断在编辑与保存时即时更新，可在 VSCode “问题”面板查看并定位。
+说明：诊断在编辑与保存时即时更新，可在 VS Code“问题”面板查看并定位。
 
 ### 代码重构
 
@@ -221,7 +240,7 @@ thrift-support symbols --json src/my.thrift
 
 ### 配置选项
 
-在 VSCode 设置中可以配置以下选项：
+在 VS Code 设置中可以配置以下选项：
 
 ```json
 {
@@ -276,7 +295,7 @@ struct User {
 
 1. **GitHub Issues**：在 [项目仓库](https://github.com/tzzs/vsce-thrift-support) 中创建 Issue
 2. **描述问题**：请详细描述遇到的问题，包括：
-    - VSCode 版本
+    - VS Code 版本
     - 扩展版本
     - 重现步骤
     - 期望行为

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Use this page as the repository-local map for agent and contributor documentatio
 | [annotation-policy.md](annotation-policy.md) | Formatter annotation and alignment policy | Update when formatter alignment semantics change |
 | [advanced-features.md](advanced-features.md) | Stream, sink, interaction, and experimental syntax examples | Update when grammar/parser support changes |
 | [settings-reference.md](settings-reference.md) | VS Code settings keys, defaults, examples, and legacy fallback notes | Update when `package.json#contributes.configuration` changes |
+| [../packages/cli/README.md](../packages/cli/README.md) | CLI installation, commands, line-range formatting, configuration, and exit codes | Update when CLI flags or behavior change |
 | [release-verification.md](release-verification.md) | Release automation chain and local/package verification commands | Update when GitHub Actions release gates change |
 | [release-channels.md](release-channels.md) | Stable/pre-release channel policy and adoption metrics workflow | Update when Marketplace, Open VSX, or npm release strategy changes |
 | [security-model.md](security-model.md) | Workspace Trust, file access, CLI write, package, and future AI/MCP security boundaries | Update when security posture or workspace access changes |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thrift-support",
   "displayName": "Thrift Support",
-  "description": "Apache Thrift language support: syntax highlighting, formatting, diagnostics, navigation, completion, and rename",
+  "description": "Apache Thrift language intelligence for VS Code, with a companion CLI for automation and CI/CD",
   "version": "3.2.0",
   "publisher": "tanzz",
   "icon": "icon.png",
@@ -52,6 +52,7 @@
     "navigation",
     "completion",
     "rename",
+    "cli",
     "vscode extension"
   ],
   "main": "./dist/extension.js",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,6 +27,7 @@ Options:
   --write, -w             Write formatted output back to files
   --stdin                 Read from stdin, write to stdout
   --stdin-filepath <p>    Filepath hint used with --stdin for config lookup
+  --range <start>:<end>   Format only lines start..end (1-based, inclusive)
   --indent-size <n>       Spaces per indent level (default: 4)
   --max-line-length <n>   Target max line length (default: 100)
   --trailing-comma <m>    preserve | add | remove  (default: preserve)
@@ -44,7 +45,14 @@ thrift-support format --write src/
 
 # Pipe through stdin
 cat myfile.thrift | thrift-support format --stdin
+
+# Format only lines 12 through 18
+thrift-support format --range 12:18 src/*.thrift
 ```
+
+`--range` formats only the selected lines and leaves the rest of the file
+untouched. The indentation context is derived from the lines before the
+range, matching the VS Code extension's "Format Selection" behavior.
 
 ### `lint`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # thrift-support
 
-CLI tool for Apache Thrift IDL: format, lint, parse, and list symbols.
+Apache Thrift IDL CLI powered by the same shared core as the Thrift Support VS Code extension. It formats whole files or line ranges, runs diagnostics, outputs AST JSON, and lists symbols.
 
 [![npm](https://img.shields.io/npm/v/thrift-support)](https://www.npmjs.com/package/thrift-support)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -142,9 +142,12 @@ The CLI resolves options in this order (highest priority first):
 
 ## Relation to the VS Code Extension
 
-This package contains the same formatting and diagnostic engine as the
-[Thrift Support VS Code extension](https://marketplace.visualstudio.com/items?itemName=tanzz.thrift-support).
-Options map directly to `thrift.format.*` settings in VS Code.
+This package and the
+[Thrift Support VS Code extension](https://marketplace.visualstudio.com/items?itemName=tanzz.thrift-support)
+both use `@tanzz/thrift-core` for parsing and language behavior. CLI
+`format --range` and VS Code **Format Selection** therefore derive indentation
+context through the same implementation. Formatting options map directly to
+the extension's `thrift.format.*` settings.
 
 ## License
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "thrift-support",
     "version": "3.1.0",
-    "description": "CLI tool for Apache Thrift IDL: format, lint, parse, symbols",
+    "description": "Apache Thrift IDL CLI for file/range formatting, diagnostics, AST output, and symbols",
     "bin": {
         "thrift-support": "./dist/cli.js"
     },

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -19,6 +19,7 @@ export interface ParsedArgs {
     maxLineLength?: number;
     trailingComma?: 'preserve' | 'add' | 'remove';
     collectionStyle?: 'preserve' | 'multiline' | 'auto';
+    range?: {startLine: number; endLine: number};
     // Lint
     severity?: 'error' | 'warning' | 'all';
     json: boolean;
@@ -145,6 +146,21 @@ export function parseArgs(argv: string[]): ParsedArgs {
                 const val = consumeNextArg(args, i, '--collection-style');
                 if (!COLLECTION_STYLE_VALUES.has(val)) {parseError(`--collection-style must be one of: preserve, multiline, auto`);}
                 result.collectionStyle = val as 'preserve' | 'multiline' | 'auto';
+                i++;
+                break;
+            }
+            case '--range': {
+                const val = consumeNextArg(args, i, '--range');
+                const m = val.match(/^(\d+):(\d+)$/);
+                if (m === null) {
+                    parseError('--range must be in the form <startLine>:<endLine> (1-based, inclusive)');
+                }
+                const startLine = parseInt(m[1], 10);
+                const endLine = parseInt(m[2], 10);
+                if (startLine < 1 || endLine < startLine) {
+                    parseError('--range must satisfy 1 <= startLine <= endLine');
+                }
+                result.range = {startLine: startLine - 1, endLine: endLine - 1};
                 i++;
                 break;
             }

--- a/packages/cli/src/commands/format.ts
+++ b/packages/cli/src/commands/format.ts
@@ -93,12 +93,19 @@ function formatRange(
 ): string {
     const lines = content.split(/\r?\n/);
     const lastLine = Math.max(0, lines.length - 1);
-    const startLine = Math.max(0, Math.min(range.startLine, lastLine));
+
+    // 请求的 range 完全超出文件范围时无操作，避免误格式化最后一行
+    if (range.startLine > lastLine) {
+        return content;
+    }
+
+    const startLine = Math.max(0, range.startLine);
     const endLine = Math.max(startLine, Math.min(range.endLine, lastLine));
 
-    // 上下文推导：解析 range 之前（含起始行）的文本
-    const beforeContent = lines.slice(0, startLine + 1).join('\n');
-    const initialContext = computeFormattingContext(beforeContent, startLine, `file://${filePath}#range`);
+    // 上下文推导：解析 range 起始行之前（不含该行）的文本，
+    // 与 VS Code 非缓存路径（getText(0,0 → start)）语义一致
+    const beforeContent = lines.slice(0, startLine).join('\n');
+    const initialContext = computeFormattingContext(beforeContent, Math.max(0, startLine - 1), `file://${filePath}#range`);
 
     const rangeText = lines.slice(startLine, endLine + 1).join('\n');
     const formattedRange = formatter.format(rangeText, {...options, initialContext});

--- a/packages/cli/src/commands/format.ts
+++ b/packages/cli/src/commands/format.ts
@@ -1,9 +1,15 @@
 /**
  * format 命令：格式化 Thrift IDL 文件。
+ * 支持整文件与 --range 部分格式化。
  */
 import * as fs from 'fs';
-import {normalizeFormattingOptions, ThriftFormatter} from '@tanzz/thrift-core';
-import type {ThriftFormattingConfigInput, ThriftFormattingOptions} from '@tanzz/thrift-core';
+import {
+    computeFormattingContext,
+    normalizeFormattingOptions,
+    ThriftFormatter,
+    ThriftFormattingOptions
+} from '@tanzz/thrift-core';
+import type {ThriftFormattingConfigInput} from '@tanzz/thrift-core';
 import type {ParsedArgs} from '../args';
 
 export function runFormat(
@@ -20,7 +26,7 @@ export function runFormat(
             process.stderr.write('Error: --write cannot be used with --stdin.\n');
             return 2;
         }
-        return formatStdin(formatter, options, args.check);
+        return formatStdin(formatter, options, args);
     }
 
     if (files.length === 0) {
@@ -41,7 +47,9 @@ export function runFormat(
 
         let formatted: string;
         try {
-            formatted = formatter.format(content, options);
+            formatted = args.range !== undefined
+                ? formatRange(formatter, content, options, args.range, filePath)
+                : formatter.format(content, options);
         } catch (error) {
             process.stderr.write(`Error: Formatting failed for "${filePath}": ${error instanceof Error ? error.message : String(error)}\n`);
             return 3;
@@ -71,7 +79,39 @@ export function runFormat(
     return hasUnformatted ? 1 : 0;
 }
 
-function formatStdin(formatter: ThriftFormatter, options: ThriftFormattingOptions, checkMode: boolean): number {
+/**
+ * 部分格式化：只格式化 [startLine, endLine]（0-based，含两端）内的文本，
+ * 其余内容原样保留。起始上下文由 range 之前的文本推导，与 VS Code
+ * "Format Selection" 行为一致。
+ */
+function formatRange(
+    formatter: ThriftFormatter,
+    content: string,
+    options: ThriftFormattingOptions,
+    range: {startLine: number; endLine: number},
+    filePath: string
+): string {
+    const lines = content.split(/\r?\n/);
+    const lastLine = Math.max(0, lines.length - 1);
+    const startLine = Math.max(0, Math.min(range.startLine, lastLine));
+    const endLine = Math.max(startLine, Math.min(range.endLine, lastLine));
+
+    // 上下文推导：解析 range 之前（含起始行）的文本
+    const beforeContent = lines.slice(0, startLine + 1).join('\n');
+    const initialContext = computeFormattingContext(beforeContent, startLine, `file://${filePath}#range`);
+
+    const rangeText = lines.slice(startLine, endLine + 1).join('\n');
+    const formattedRange = formatter.format(rangeText, {...options, initialContext});
+
+    const result = [
+        ...lines.slice(0, startLine),
+        ...formattedRange.split('\n'),
+        ...lines.slice(endLine + 1)
+    ];
+    return result.join('\n');
+}
+
+function formatStdin(formatter: ThriftFormatter, options: ThriftFormattingOptions, args: ParsedArgs): number {
     const chunks: Buffer[] = [];
     const buf = Buffer.alloc(65536);
     let bytesRead: number;
@@ -81,8 +121,10 @@ function formatStdin(formatter: ThriftFormatter, options: ThriftFormattingOption
 
     const content = Buffer.concat(chunks).toString('utf-8');
     try {
-        const formatted = formatter.format(content, options);
-        if (checkMode) {
+        const formatted = args.range !== undefined
+            ? formatRange(formatter, content, options, args.range, args.stdinFilepath ?? '<stdin>')
+            : formatter.format(content, options);
+        if (args.check) {
             if (formatted !== content) {
                 process.stderr.write('<stdin>: unformatted\n');
                 return 1;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,6 +37,7 @@ Format Options:
   --write, -w             Write formatted output back to files
   --stdin                 Read from stdin, output to stdout
   --stdin-filepath <p>    Used with --stdin for config file lookup
+  --range <start>:<end>   Format only lines start..end (1-based, inclusive)
   --indent-size <n>       Indent size (default: 4)
   --max-line-length <n>   Max line length (default: 100)
   --trailing-comma <m>    preserve | add | remove
@@ -58,6 +59,7 @@ Symbols Options:
 Examples:
   thrift-support format --check src/**/*.thrift
   thrift-support format --write src/
+  thrift-support format --range 12:18 src/*.thrift
   thrift-support lint --severity error src/**/*.thrift
   thrift-support parse service.thrift | jq '.body[0]'
   thrift-support symbols --json service.thrift

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@tanzz/thrift-core",
     "version": "3.2.0",
+    "description": "Shared Apache Thrift IDL parser, formatter, diagnostics, and language primitives",
     "private": true,
     "main": "./out/index.js",
     "types": "./out/index.d.ts",

--- a/packages/core/src/formatter/format-context.ts
+++ b/packages/core/src/formatter/format-context.ts
@@ -28,8 +28,8 @@ const BLOCK_START_RE = /^(struct|union|exception|enum|senum|service|interaction)
 /**
  * 计算格式化上下文的纯文本入口（无 VS Code 依赖）。
  *
- * @param parseContent - 用于推导上下文的文本：通常是 range 之前（含起始行）的完整内容，
- *                       或整份文档内容。AST 无效时会退化为逐行扫描。
+ * @param parseContent - 用于推导上下文的文本：通常是 range 起始行之前的完整内容，
+ *                       或整份文档内容。AST 无效时会退化为逐行扫描（仅扫到 boundaryLine）。
  * @param boundaryLine - 边界行号（基于 parseContent 的 0-based 行号）。
  *                       包含该行的块节点会计入上下文。
  * @param uri - 可选缓存键（默认使用内存 key）。
@@ -53,7 +53,7 @@ export function computeFormattingContext(
         });
 
         if (!hasValidRanges) {
-            return computeContextByLineScan(parseContent.split('\n'));
+            return computeContextByLineScan(parseContent.split('\n'), boundaryLine);
         }
 
         return computeContextByAst(ast, boundaryLine);
@@ -70,7 +70,8 @@ function computeContextByAst(ast: nodes.ThriftDocument, boundaryLine: number): F
     const stack: BlockKind[] = [];
 
     const traverse = (node: nodes.ThriftNode) => {
-        if (node.range !== undefined && node.range.start.line <= boundaryLine && node.range.end.line >= boundaryLine) {
+        if (node.range !== undefined && node.range !== null &&
+            node.range.start.line <= boundaryLine && node.range.end.line >= boundaryLine) {
             if (node.type === nodes.ThriftNodeType.Struct ||
                 node.type === nodes.ThriftNodeType.Union ||
                 node.type === nodes.ThriftNodeType.Exception) {
@@ -106,9 +107,12 @@ function computeContextByAst(ast: nodes.ThriftDocument, boundaryLine: number): F
     return {indentLevel: stack.length, inStruct, inEnum, inService, inInteraction};
 }
 
-function computeContextByLineScan(lines: string[]): FormattingContext {
+function computeContextByLineScan(lines: string[], boundaryLine: number): FormattingContext {
     const stack: BlockKind[] = [];
-    for (const rawLine of lines) {
+    // 只扫描到边界行：boundary 之后的块（含其后闭合的块）不应影响边界处的上下文
+    const scanLimit = Math.min(Math.max(boundaryLine, 0), lines.length - 1);
+    for (let i = 0; i <= scanLimit; i++) {
+        const rawLine = lines[i];
         const line = rawLine.replace(/\/\/.*$/, '').replace(/#.*$/, '').trim();
         if (!line) {
             continue;

--- a/packages/core/src/formatter/format-context.ts
+++ b/packages/core/src/formatter/format-context.ts
@@ -1,0 +1,140 @@
+import * as nodes from '../ast/nodes.types';
+import {ThriftParser} from '../ast/parser';
+
+/**
+ * 格式化片段所需的起始上下文：缩进层级与所在块类型。
+ * 由 range 之前的文本推导，使片段格式化与整文件格式化结果一致。
+ */
+export interface FormattingContext {
+    indentLevel: number;
+    inStruct: boolean;
+    inEnum: boolean;
+    inService: boolean;
+    inInteraction: boolean;
+}
+
+export const DEFAULT_FORMATTING_CONTEXT: FormattingContext = {
+    indentLevel: 0,
+    inStruct: false,
+    inEnum: false,
+    inService: false,
+    inInteraction: false
+};
+
+type BlockKind = 'struct' | 'enum' | 'service' | 'interaction';
+
+const BLOCK_START_RE = /^(struct|union|exception|enum|senum|service|interaction)\b/;
+
+/**
+ * 计算格式化上下文的纯文本入口（无 VS Code 依赖）。
+ *
+ * @param parseContent - 用于推导上下文的文本：通常是 range 之前（含起始行）的完整内容，
+ *                       或整份文档内容。AST 无效时会退化为逐行扫描。
+ * @param boundaryLine - 边界行号（基于 parseContent 的 0-based 行号）。
+ *                       包含该行的块节点会计入上下文。
+ * @param uri - 可选缓存键（默认使用内存 key）。
+ */
+export function computeFormattingContext(
+    parseContent: string,
+    boundaryLine: number,
+    uri = 'inmemory://format-context'
+): FormattingContext {
+    try {
+        if (!parseContent) {
+            return {...DEFAULT_FORMATTING_CONTEXT};
+        }
+
+        const ast = ThriftParser.parseContentWithCache(uri, parseContent);
+
+        const hasValidRanges = ast.body.some((node) => {
+            return node.range !== null && node.range !== undefined &&
+                typeof node.range.start?.line === 'number' &&
+                typeof node.range.end?.line === 'number';
+        });
+
+        if (!hasValidRanges) {
+            return computeContextByLineScan(parseContent.split('\n'));
+        }
+
+        return computeContextByAst(ast, boundaryLine);
+    } catch {
+        return {...DEFAULT_FORMATTING_CONTEXT};
+    }
+}
+
+function computeContextByAst(ast: nodes.ThriftDocument, boundaryLine: number): FormattingContext {
+    let inStruct = false;
+    let inEnum = false;
+    let inService = false;
+    let inInteraction = false;
+    const stack: BlockKind[] = [];
+
+    const traverse = (node: nodes.ThriftNode) => {
+        if (node.range !== undefined && node.range.start.line <= boundaryLine && node.range.end.line >= boundaryLine) {
+            if (node.type === nodes.ThriftNodeType.Struct ||
+                node.type === nodes.ThriftNodeType.Union ||
+                node.type === nodes.ThriftNodeType.Exception) {
+                stack.push('struct');
+                inStruct = true;
+            } else if (node.type === nodes.ThriftNodeType.Enum) {
+                stack.push('enum');
+                inEnum = true;
+            } else if (node.type === nodes.ThriftNodeType.Service) {
+                stack.push('service');
+                inService = true;
+            } else if (node.type === nodes.ThriftNodeType.Interaction) {
+                stack.push('interaction');
+                inInteraction = true;
+            }
+        }
+
+        if ((node as nodes.ThriftDocument).body !== undefined) {
+            (node as nodes.ThriftDocument).body.forEach(traverse);
+        } else if ((node as nodes.Struct).fields !== undefined) {
+            (node as nodes.Struct).fields.forEach(traverse);
+        } else if ((node as nodes.Enum).members !== undefined) {
+            (node as nodes.Enum).members.forEach(traverse);
+        } else if ((node as nodes.Service).functions !== undefined) {
+            (node as nodes.Service).functions.forEach(traverse);
+        } else if ((node as nodes.Interaction).functions !== undefined) {
+            (node as nodes.Interaction).functions.forEach(traverse);
+        }
+    };
+
+    ast.body.forEach(traverse);
+
+    return {indentLevel: stack.length, inStruct, inEnum, inService, inInteraction};
+}
+
+function computeContextByLineScan(lines: string[]): FormattingContext {
+    const stack: BlockKind[] = [];
+    for (const rawLine of lines) {
+        const line = rawLine.replace(/\/\/.*$/, '').replace(/#.*$/, '').trim();
+        if (!line) {
+            continue;
+        }
+        const startMatch = line.match(BLOCK_START_RE);
+        if (startMatch && line.includes('{')) {
+            const type = startMatch[1];
+            if (type === 'enum' || type === 'senum') {
+                stack.push('enum');
+            } else if (type === 'service') {
+                stack.push('service');
+            } else if (type === 'interaction') {
+                stack.push('interaction');
+            } else {
+                stack.push('struct');
+            }
+        }
+        if (line.includes('}')) {
+            stack.pop();
+        }
+    }
+    return {
+        indentLevel: stack.length,
+        inStruct: stack.includes('struct'),
+        inEnum: stack.includes('enum'),
+        inService: stack.includes('service'),
+        inInteraction: stack.includes('interaction')
+    };
+}

--- a/packages/core/src/formatter/format-context.ts
+++ b/packages/core/src/formatter/format-context.ts
@@ -113,7 +113,16 @@ function computeContextByLineScan(lines: string[], boundaryLine: number): Format
     const scanLimit = Math.min(Math.max(boundaryLine, 0), lines.length - 1);
     for (let i = 0; i <= scanLimit; i++) {
         const rawLine = lines[i];
-        const line = rawLine.replace(/\/\/.*$/, '').replace(/#.*$/, '').trim();
+        const slashComment = rawLine.indexOf('//');
+        const hashComment = rawLine.indexOf('#');
+        let commentStart = rawLine.length;
+        if (slashComment >= 0) {
+            commentStart = slashComment;
+        }
+        if (hashComment >= 0) {
+            commentStart = Math.min(commentStart, hashComment);
+        }
+        const line = rawLine.slice(0, commentStart).trim();
         if (!line) {
             continue;
         }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,8 @@ export type {ExtractTypeEdits, ExtractTypeTarget, MoveTypeTarget, PositionLike, 
 // Formatter
 export {ThriftFormatter} from './formatter/index';
 export {formatThriftContent} from './formatter/formatter-core';
+export {computeFormattingContext, DEFAULT_FORMATTING_CONTEXT} from './formatter/format-context';
+export type {FormattingContext} from './formatter/format-context';
 
 // Diagnostics
 export {DIAGNOSTIC_CODES, UNKNOWN_TYPE_DIAGNOSTIC_CODES} from './diagnostics/diagnostic-codes';

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@tanzz/thrift-vscode",
     "private": true,
-    "description": "VS Code extension source for thrift-support (requires @tanzz/thrift-core)",
+    "description": "VS Code integration for Thrift Support, backed by the shared @tanzz/thrift-core package",
     "dependencies": {
         "@tanzz/thrift-core": "workspace:*"
     },

--- a/packages/vscode/src/formatting-bridge/context.ts
+++ b/packages/vscode/src/formatting-bridge/context.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import {computeFormattingContext} from '@tanzz/thrift-core';
+import {computeFormattingContext, DEFAULT_FORMATTING_CONTEXT} from '@tanzz/thrift-core';
 import type {FormattingContext} from '@tanzz/thrift-core';
 
 export type {FormattingContext} from '@tanzz/thrift-core';
@@ -21,11 +21,11 @@ export function computeInitialContext(
             const content = document.getText();
             // 光标位于行首时，上一行才是边界：避免把当前行所在块计入上下文
             const boundaryLine = start.character === 0 ? Math.max(start.line - 1, 0) : start.line;
-            return computeFormattingContext(content, boundaryLine, document.uri.toString());
+            return computeFormattingContext(content, boundaryLine, document.uri.fsPath ?? document.uri.toString());
         }
         const before = document.getText(new vscode.Range(new vscode.Position(0, 0), start));
         if (!before) {
-            return {indentLevel: 0, inStruct: false, inEnum: false, inService: false, inInteraction: false};
+            return {...DEFAULT_FORMATTING_CONTEXT};
         }
         const baseKey = document.uri !== undefined && typeof document.uri.toString === 'function'
             ? document.uri.toString()
@@ -33,6 +33,6 @@ export function computeInitialContext(
         const boundaryLine = Math.max(0, before.split('\n').length - 1);
         return computeFormattingContext(before, boundaryLine, `${baseKey}#range`);
     } catch {
-        return {indentLevel: 0, inStruct: false, inEnum: false, inService: false, inInteraction: false};
+        return {...DEFAULT_FORMATTING_CONTEXT};
     }
 }

--- a/packages/vscode/src/formatting-bridge/context.ts
+++ b/packages/vscode/src/formatting-bridge/context.ts
@@ -1,14 +1,8 @@
 import * as vscode from 'vscode';
-import {ThriftParser} from '@tanzz/thrift-core';
-import {nodes} from '@tanzz/thrift-core';
+import {computeFormattingContext} from '@tanzz/thrift-core';
+import type {FormattingContext} from '@tanzz/thrift-core';
 
-export interface FormattingContext {
-    indentLevel: number;
-    inStruct: boolean;
-    inEnum: boolean;
-    inService: boolean;
-    inInteraction: boolean;
-}
+export type {FormattingContext} from '@tanzz/thrift-core';
 
 /**
  * Compute formatting context from the content before the selection start.
@@ -23,118 +17,21 @@ export function computeInitialContext(
     useCachedAst = false
 ): FormattingContext {
     try {
-        let ast: nodes.ThriftDocument;
-        let beforeLines: string[] | null = null;
-        let boundaryLine = start.line;
-
         if (useCachedAst) {
-            ast = ThriftParser.parseWithCacheByVersion(document.uri.fsPath, document.getText(), document.version);
-            if (start.character === 0) {
-                boundaryLine = Math.max(start.line - 1, 0);
-            }
-        } else {
-            const before = document.getText(new vscode.Range(new vscode.Position(0, 0), start));
-            if (!before) {
-                return {indentLevel: 0, inStruct: false, inEnum: false, inService: false, inInteraction: false};
-            }
-            const baseKey = document.uri !== undefined && typeof document.uri.toString === 'function'
-                ? document.uri.toString()
-                : 'inmemory://range';
-            ast = ThriftParser.parseContentWithCache(`${baseKey}#range`, before);
-            beforeLines = before.split('\n');
-            boundaryLine = Math.max(0, beforeLines.length - 1);
+            const content = document.getText();
+            // 光标位于行首时，上一行才是边界：避免把当前行所在块计入上下文
+            const boundaryLine = start.character === 0 ? Math.max(start.line - 1, 0) : start.line;
+            return computeFormattingContext(content, boundaryLine, document.uri.toString());
         }
-
-        const hasValidRanges = ast.body.some((node) => {
-            return node.range !== null && node.range !== undefined &&
-                typeof node.range.start?.line === 'number' &&
-                typeof node.range.end?.line === 'number';
-        });
-
-        if (!hasValidRanges) {
-            if (!beforeLines) {
-                const before = document.getText(new vscode.Range(new vscode.Position(0, 0), start));
-                beforeLines = before.split('\n');
-            }
-            const stack: Array<'struct' | 'enum' | 'service' | 'interaction'> = [];
-            for (const rawLine of beforeLines) {
-                const line = rawLine.replace(/\/\/.*$/, '').replace(/#.*$/, '').trim();
-                if (!line) {
-                    continue;
-                }
-                const startMatch = line.match(/^(struct|union|exception|enum|senum|service|interaction)\b/);
-                if (startMatch && line.includes('{')) {
-                    const type = startMatch[1];
-                    if (type === 'enum' || type === 'senum') {
-                        stack.push('enum');
-                    } else if (type === 'service') {
-                        stack.push('service');
-                    } else if (type === 'interaction') {
-                        stack.push('interaction');
-                    } else {
-                        stack.push('struct');
-                    }
-                }
-                if (line.includes('}')) {
-                    stack.pop();
-                }
-            }
-            return {
-                indentLevel: stack.length,
-                inStruct: stack.includes('struct'),
-                inEnum: stack.includes('enum'),
-                inService: stack.includes('service'),
-                inInteraction: stack.includes('interaction')
-            };
+        const before = document.getText(new vscode.Range(new vscode.Position(0, 0), start));
+        if (!before) {
+            return {indentLevel: 0, inStruct: false, inEnum: false, inService: false, inInteraction: false};
         }
-
-        let inStruct = false;
-        let inEnum = false;
-        let inService = false;
-        let inInteraction = false;
-        const stack: Array<'struct' | 'enum' | 'service' | 'interaction'> = [];
-
-        const traverse = (node: nodes.ThriftNode) => {
-            if (node.range !== undefined && node.range.start.line <= boundaryLine && node.range.end.line >= boundaryLine) {
-                if (node.type === nodes.ThriftNodeType.Struct ||
-                    node.type === nodes.ThriftNodeType.Union ||
-                    node.type === nodes.ThriftNodeType.Exception) {
-                    stack.push('struct');
-                    inStruct = true;
-                } else if (node.type === nodes.ThriftNodeType.Enum) {
-                    stack.push('enum');
-                    inEnum = true;
-                } else if (node.type === nodes.ThriftNodeType.Service) {
-                    stack.push('service');
-                    inService = true;
-                } else if (node.type === nodes.ThriftNodeType.Interaction) {
-                    stack.push('interaction');
-                    inInteraction = true;
-                }
-            }
-
-            if ((node as nodes.ThriftDocument).body !== undefined) {
-                (node as nodes.ThriftDocument).body.forEach(traverse);
-            } else if ((node as nodes.Struct).fields !== undefined) {
-                (node as nodes.Struct).fields.forEach(traverse);
-            } else if ((node as nodes.Enum).members !== undefined) {
-                (node as nodes.Enum).members.forEach(traverse);
-            } else if ((node as nodes.Service).functions !== undefined) {
-                (node as nodes.Service).functions.forEach(traverse);
-            } else if ((node as nodes.Interaction).functions !== undefined) {
-                (node as nodes.Interaction).functions.forEach(traverse);
-            }
-        };
-
-        ast.body.forEach(traverse);
-
-        return {
-            indentLevel: stack.length,
-            inStruct,
-            inEnum,
-            inService,
-            inInteraction
-        };
+        const baseKey = document.uri !== undefined && typeof document.uri.toString === 'function'
+            ? document.uri.toString()
+            : 'inmemory://range';
+        const boundaryLine = Math.max(0, before.split('\n').length - 1);
+        return computeFormattingContext(before, boundaryLine, `${baseKey}#range`);
     } catch {
         return {indentLevel: 0, inStruct: false, inEnum: false, inService: false, inInteraction: false};
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,15 +714,15 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1024,8 +1024,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1066,8 +1066,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs-constants@1.0.0:
@@ -1262,8 +1262,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1313,8 +1313,8 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1852,8 +1852,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.26.0:
-    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -2184,7 +2184,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2330,7 +2330,7 @@ snapshots:
       '@textlint/types': 15.7.1
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -2529,7 +2529,7 @@ snapshots:
       cheerio: 1.2.0
       cockatiel: 3.2.1
       commander: 12.1.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       glob: 13.0.6
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
@@ -2574,7 +2574,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2625,16 +2625,16 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2713,7 +2713,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.26.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -2984,7 +2984,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -3021,7 +3021,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -3212,7 +3212,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -3275,7 +3275,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -3326,7 +3326,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -3355,15 +3355,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimist@1.2.8:
     optional: true
@@ -3384,7 +3384,7 @@ snapshots:
       glob: 13.0.6
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -3549,7 +3549,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:
@@ -3852,7 +3852,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.26.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,16 @@ allowBuilds:
   esbuild: true
   keytar: true
 
+minimumReleaseAgeExclude:
+  - form-data@4.0.6
+  - undici@7.29.0
+  - brace-expansion@1.1.18
+  - brace-expansion@2.1.4
+  - brace-expansion@5.0.9
+  - js-yaml@4.3.1
+  - linkify-it@5.0.2
+  - fast-uri@3.1.5
+
 # CVE remediations on transitive deps. pnpm 11 no longer reads
 # package.json#pnpm.overrides (silently — see pnpm/pnpm#11536), so these
 # MUST live here to keep the supply-chain fixes effective.

--- a/tests/cli/test-cli-integration.js
+++ b/tests/cli/test-cli-integration.js
@@ -91,6 +91,121 @@ describe('CLI integration', () => {
             const {code} = run(['format']);
             assert.notStrictEqual(code, 0);
         });
+
+        it('--range formats only the selected lines', () => {
+            const input = [
+                'struct User {',
+                '  1: string name',
+                '  2: i32   age',
+                '}',
+                '',
+                'enum Color {',
+                '    RED = 1',
+                '}',
+                ''
+            ].join('\n');
+            const f = tmpFile('cli-fmt-range.thrift', input);
+            try {
+                // struct 字段在 2~3 行（1-based），enum 在 7 行：只格式化 2:3
+                const {code, stdout} = run(['format', '--range', '2:3', f]);
+                assert.strictEqual(code, 0);
+                const expected = [
+                    'struct User {',
+                    '    1: string name',
+                    '    2: i32    age',
+                    '}',
+                    '',
+                    'enum Color {',
+                    '    RED = 1',
+                    '}',
+                    ''
+                ].join('\n');
+                assert.strictEqual(stdout, expected, 'only the range should be formatted');
+            } finally {
+                fs.unlinkSync(f);
+            }
+        });
+
+        it('--range keeps out-of-range lines untouched', () => {
+            const input = [
+                'enum Color {',
+                '    RED = 1',
+                '  BLUE = 2',
+                '}',
+                ''
+            ].join('\n');
+            const f = tmpFile('cli-fmt-range-keep.thrift', input);
+            try {
+                // 只格式化 2 行；3 行（BLUE 缩进不对）必须保持原样
+                const {code, stdout} = run(['format', '--range', '2:2', f]);
+                assert.strictEqual(code, 0);
+                const lines = stdout.split('\n');
+                assert.strictEqual(lines[1], '    RED = 1', 'line 2 should be formatted');
+                assert.strictEqual(lines[2], '  BLUE = 2', 'line 3 must remain untouched');
+            } finally {
+                fs.unlinkSync(f);
+            }
+        });
+
+        it('--range --check reports only when range is unformatted', () => {
+            const input = [
+                'struct User {',
+                '  1: string name',
+                '}',
+                ''
+            ].join('\n');
+            const f = tmpFile('cli-fmt-range-check.thrift', input);
+            try {
+                // range 内（2 行）缩进不正确 → 失败
+                const dirty = run(['format', '--check', '--range', '2:2', f]);
+                assert.notStrictEqual(dirty.code, 0);
+                assert.ok(dirty.stdout.includes(f), 'unformatted file path should be printed');
+                // 格式化后再检查同一 range → 通过
+                run(['format', '--write', '--range', '2:2', f]);
+                const clean = run(['format', '--check', '--range', '2:2', f]);
+                assert.strictEqual(clean.code, 0, 'formatted range should pass --check');
+            } finally {
+                fs.unlinkSync(f);
+            }
+        });
+
+        it('--range formats a field line inside a struct', () => {
+            const input = [
+                'struct User {',
+                '    1: i32  age',
+                '}',
+                ''
+            ].join('\n');
+            const f = tmpFile('cli-fmt-range-inner.thrift', input);
+            try {
+                // 只格式化 2 行：多余空格被规整，缩进由 struct 上下文推导（4 空格）
+                const {code, stdout} = run(['format', '--range', '2:2', f]);
+                assert.strictEqual(code, 0);
+                const lines = stdout.split('\n');
+                assert.strictEqual(lines[1], '    1: i32 age', 'field spacing should be normalized in-range');
+            } finally {
+                fs.unlinkSync(f);
+            }
+        });
+
+        it('--range rejects start > end', () => {
+            const f = tmpFile('cli-fmt-range-invalid.thrift', 'struct Foo {}\n');
+            try {
+                const {code, stderr} = run(['format', '--range', '5:2', f]);
+                assert.notStrictEqual(code, 0);
+                assert.ok(stderr.includes('--range'), 'should report the bad option');
+            } finally {
+                fs.unlinkSync(f);
+            }
+        });
+
+        it('--range supports --stdin', () => {
+            const input = 'struct User {\n  1: string name\n}\n';
+            const {code, stdout} = run(['format', '--stdin', '--range', '2:2'], {input});
+            assert.strictEqual(code, 0);
+            const lines = stdout.split('\n');
+            assert.strictEqual(lines[1], '    1: string name', 'field line should be formatted');
+        });
     });
 
     describe('lint command', () => {

--- a/tests/cli/test-cli-integration.js
+++ b/tests/cli/test-cli-integration.js
@@ -169,6 +169,39 @@ describe('CLI integration', () => {
             }
         });
 
+        it('--range starting on a block declaration line does not indent it', () => {
+            const input = [
+                'struct User {',
+                '  1: string name',
+                '}',
+                ''
+            ].join('\n');
+            const f = tmpFile('cli-fmt-range-opener.thrift', input);
+            try {
+                // 1 行是 struct 声明行：起始上下文不应把该块算入，声明行保持列 0
+                const {code, stdout} = run(['format', '--range', '1:2', f]);
+                assert.strictEqual(code, 0);
+                const lines = stdout.split('\n');
+                assert.strictEqual(lines[0], 'struct User {', 'block declaration line must not be indented');
+                assert.strictEqual(lines[1], '    1: string name', 'field should use struct indent');
+            } finally {
+                fs.unlinkSync(f);
+            }
+        });
+
+        it('--range beyond EOF is a no-op', () => {
+            const f = tmpFile('cli-fmt-range-eof.thrift', 'struct Foo {}\n');
+            try {
+                const {code, stdout} = run(['format', '--range', '99:100', f]);
+                assert.strictEqual(code, 0);
+                assert.strictEqual(stdout, 'struct Foo {}\n', 'out-of-range request must not format anything');
+                const {code: checkCode} = run(['format', '--check', '--range', '99:100', f]);
+                assert.strictEqual(checkCode, 0, 'out-of-range --check must pass');
+            } finally {
+                fs.unlinkSync(f);
+            }
+        });
+
         it('--range formats a field line inside a struct', () => {
             const input = [
                 'struct User {',

--- a/tests/cli/test-cli-units.js
+++ b/tests/cli/test-cli-units.js
@@ -471,6 +471,16 @@ describe('CLI unit tests', () => {
             assert.strictEqual(r.stdin, true);
         });
 
+        it('parses format --range as 0-based lines', () => {
+            const r = argsMod.parseArgs(['node', 'cli.js', 'format', '--range', '12:18', 'f.thrift']);
+            assert.deepStrictEqual(r.range, {startLine: 11, endLine: 17});
+        });
+
+        it('parses format --range single line', () => {
+            const r = argsMod.parseArgs(['node', 'cli.js', 'format', '--range', '3:3', 'f.thrift']);
+            assert.deepStrictEqual(r.range, {startLine: 2, endLine: 2});
+        });
+
         it('parses --stdin-filepath option', () => {
             const r = argsMod.parseArgs(['node', 'cli.js', 'format', '--stdin', '--stdin-filepath', 'x.thrift']);
             assert.strictEqual(r.stdinFilepath, 'x.thrift');

--- a/tests/src/formatter/test-format-context.js
+++ b/tests/src/formatter/test-format-context.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('assert');
+
+const {ThriftParser} = require('../../../out/ast/parser.js');
+const {ThriftNodeType} = require('../../../out/ast/nodes.types.js');
+const {
+    computeFormattingContext,
+    DEFAULT_FORMATTING_CONTEXT
+} = require('../../../out/formatter/format-context.js');
+
+describe('core formatting context', () => {
+    let originalParseContentWithCache;
+
+    beforeEach(() => {
+        originalParseContentWithCache = ThriftParser.parseContentWithCache;
+    });
+
+    afterEach(() => {
+        ThriftParser.parseContentWithCache = originalParseContentWithCache;
+    });
+
+    it('returns an independent default context for empty input', () => {
+        const result = computeFormattingContext('', 0);
+
+        assert.deepStrictEqual(result, DEFAULT_FORMATTING_CONTEXT);
+        assert.notStrictEqual(result, DEFAULT_FORMATTING_CONTEXT);
+    });
+
+    it('derives context from AST ranges', () => {
+        ThriftParser.parseContentWithCache = () => ({
+            body: [{
+                type: ThriftNodeType.Struct,
+                range: {start: {line: 0}, end: {line: 2}},
+                fields: []
+            }]
+        });
+
+        const result = computeFormattingContext('struct User {\n1: i32 id\n}', 1);
+
+        assert.strictEqual(result.indentLevel, 1);
+        assert.strictEqual(result.inStruct, true);
+    });
+
+    it('limits fallback scanning to the requested boundary', () => {
+        ThriftParser.parseContentWithCache = () => ({body: []});
+        const input = 'struct User {\n1: i32 id\n}\nenum Color {';
+
+        const result = computeFormattingContext(input, 1);
+
+        assert.strictEqual(result.indentLevel, 1);
+        assert.strictEqual(result.inStruct, true);
+        assert.strictEqual(result.inEnum, false);
+    });
+
+    it('ignores block markers after slash and hash comments', () => {
+        ThriftParser.parseContentWithCache = () => ({body: []});
+        const input = [
+            '// struct CommentedOut {',
+            '# enum AlsoCommentedOut {',
+            'service Api { // } must not close the service'
+        ].join('\n');
+
+        const result = computeFormattingContext(input, 2);
+
+        assert.strictEqual(result.indentLevel, 1);
+        assert.strictEqual(result.inService, true);
+        assert.strictEqual(result.inStruct, false);
+        assert.strictEqual(result.inEnum, false);
+    });
+
+    it('handles very long comment markers without changing context', () => {
+        ThriftParser.parseContentWithCache = () => ({body: []});
+        const markerCount = 250_000;
+        const input = `struct User {\n${'/'.repeat(markerCount)} }\n${'#'.repeat(markerCount)} }`;
+
+        const startedAt = Date.now();
+        const result = computeFormattingContext(input, 2);
+        const elapsedMs = Date.now() - startedAt;
+
+        assert.strictEqual(result.indentLevel, 1);
+        assert.strictEqual(result.inStruct, true);
+        assert.ok(elapsedMs < 1000, `comment scan took ${elapsedMs}ms`);
+    });
+
+    it('returns default context when parsing throws', () => {
+        ThriftParser.parseContentWithCache = () => {
+            throw new Error('parse failed');
+        };
+
+        const result = computeFormattingContext('invalid', 0);
+
+        assert.deepStrictEqual(result, DEFAULT_FORMATTING_CONTEXT);
+    });
+});

--- a/tests/src/formatting-bridge/test-context.js
+++ b/tests/src/formatting-bridge/test-context.js
@@ -80,14 +80,14 @@ describe('formatting-context', () => {
     });
 
     describe('cached AST path (useCachedAst=true)', () => {
-        let originalParseWithCache;
+        let originalParseContentWithCache;
 
         beforeEach(() => {
-            originalParseWithCache = ThriftParser.parseWithCache;
+            originalParseContentWithCache = ThriftParser.parseContentWithCache;
         });
 
         afterEach(() => {
-            ThriftParser.parseWithCache = originalParseWithCache;
+            ThriftParser.parseContentWithCache =originalParseContentWithCache;
         });
 
         it('should detect struct from AST', () => {
@@ -97,7 +97,7 @@ describe('formatting-context', () => {
                 range: makeRange(0, 0, 2, 1),
                 fields: []
             };
-            ThriftParser.parseWithCache = () => ({
+            ThriftParser.parseContentWithCache =() => ({
                 type: ThriftNodeType.Document,
                 range: makeRange(0, 0, 2, 1),
                 body: [astNode]
@@ -119,7 +119,7 @@ describe('formatting-context', () => {
                 range: makeRange(0, 0, 2, 1),
                 members: []
             };
-            ThriftParser.parseWithCache = () => ({
+            ThriftParser.parseContentWithCache =() => ({
                 type: ThriftNodeType.Document,
                 range: makeRange(0, 0, 2, 1),
                 body: [astNode]
@@ -139,7 +139,7 @@ describe('formatting-context', () => {
                 range: makeRange(0, 0, 2, 1),
                 functions: []
             };
-            ThriftParser.parseWithCache = () => ({
+            ThriftParser.parseContentWithCache =() => ({
                 type: ThriftNodeType.Document,
                 range: makeRange(0, 0, 2, 1),
                 body: [astNode]
@@ -159,7 +159,7 @@ describe('formatting-context', () => {
                 range: makeRange(0, 0, 2, 1),
                 functions: []
             };
-            ThriftParser.parseWithCache = () => ({
+            ThriftParser.parseContentWithCache =() => ({
                 type: ThriftNodeType.Document,
                 range: makeRange(0, 0, 2, 1),
                 body: [astNode]
@@ -179,7 +179,7 @@ describe('formatting-context', () => {
                 range: makeRange(0, 0, 2, 1),
                 fields: []
             };
-            ThriftParser.parseWithCache = () => ({
+            ThriftParser.parseContentWithCache =() => ({
                 type: ThriftNodeType.Document,
                 range: makeRange(0, 0, 3, 1),
                 body: [astNode]

--- a/tests/src/formatting-bridge/test-context.js
+++ b/tests/src/formatting-bridge/test-context.js
@@ -35,20 +35,20 @@ function createDoc(text, overrides) {
 }
 
 describe('formatting-context', () => {
-    let originalParseWithCache;
-    let originalParseContentWithCache;
-
-    before(() => {
-        originalParseWithCache = ThriftParser.parseWithCache;
-        originalParseContentWithCache = ThriftParser.parseContentWithCache;
-    });
-
-    after(() => {
-        ThriftParser.parseWithCache = originalParseWithCache;
-        ThriftParser.parseContentWithCache = originalParseContentWithCache;
-    });
-
+    // Mock 静态方法必须按分组隔离：describe 级 after 恢复太晚，
+    // 会把上一个分组的 mock 泄漏给后续分组（computeFormattingContext
+    // 内部经 parseContentWithCache 真实解析，mock 残留会导致误判）。
     describe('inline parse path (useCachedAst=false)', () => {
+        let originalParseContentWithCache;
+
+        beforeEach(() => {
+            originalParseContentWithCache = ThriftParser.parseContentWithCache;
+        });
+
+        afterEach(() => {
+            ThriftParser.parseContentWithCache = originalParseContentWithCache;
+        });
+
         it('should return default context for empty before text', () => {
             ThriftParser.parseContentWithCache = () => ({body: []});
 
@@ -80,6 +80,16 @@ describe('formatting-context', () => {
     });
 
     describe('cached AST path (useCachedAst=true)', () => {
+        let originalParseWithCache;
+
+        beforeEach(() => {
+            originalParseWithCache = ThriftParser.parseWithCache;
+        });
+
+        afterEach(() => {
+            ThriftParser.parseWithCache = originalParseWithCache;
+        });
+
         it('should detect struct from AST', () => {
             const astNode = {
                 type: ThriftNodeType.Struct,
@@ -187,6 +197,16 @@ describe('formatting-context', () => {
     });
 
     describe('fallback heuristic (no valid AST ranges)', () => {
+        let originalParseContentWithCache;
+
+        beforeEach(() => {
+            originalParseContentWithCache = ThriftParser.parseContentWithCache;
+        });
+
+        afterEach(() => {
+            ThriftParser.parseContentWithCache = originalParseContentWithCache;
+        });
+
         it('should detect struct keyword and brace', () => {
             const text = 'struct Foo {\n  1: i32 id\n';
             ThriftParser.parseContentWithCache = () => ({
@@ -255,6 +275,16 @@ describe('formatting-context', () => {
     });
 
     describe('error handling', () => {
+        let originalParseContentWithCache;
+
+        beforeEach(() => {
+            originalParseContentWithCache = ThriftParser.parseContentWithCache;
+        });
+
+        afterEach(() => {
+            ThriftParser.parseContentWithCache = originalParseContentWithCache;
+        });
+
         it('should return default context when parser throws', () => {
             ThriftParser.parseContentWithCache = () => {
                 throw new Error('Parse error');


### PR DESCRIPTION
## Summary

Adds partial (line-range) formatting to the CLI `format` command:

```
thrift-support format --range 12:18 src/*.thrift
```

- **`--range <start>:<end>`** (1-based, inclusive) formats only the selected lines; the rest of the file is left untouched. Works with `--write`, `--check`, and `--stdin`.
- The indentation context (struct/enum/service depth) is derived from the lines before the range, matching the VS Code extension's "Format Selection" behavior.

## Implementation

- **`@tanzz/thrift-core`**: new pure-text `computeFormattingContext()` (`packages/core/src/formatter/format-context.ts`), moved from the VS Code formatting bridge. No VS Code dependency; the CLI and the extension now share one implementation.
- **`packages/vscode`**: `formatting-bridge/context.ts` delegates to the core API (same behavior; cached-AST path now uses `parseContentWithCache` under the document's `fsPath` cache key).
- **`packages/cli`**: `--range` flag parsing (`args.ts`), range formatting in `commands/format.ts` (extract range text → compute context → format snippet → splice back), help text and README updated.
- **Tests**: CLI unit tests for `--range` parsing, integration tests for range formatting/`--check`/`--stdin` semantics and boundary cases; fixed mock isolation in `tests/src/formatting-bridge/test-context.js` (the error-handling group leaked a throwing `parseContentWithCache` stub into later test files) and corrected the dead `parseWithCache` mocks to target `parseContentWithCache`.

## Known limitations

- Column alignment (`alignTypes`/`alignComments`) applies within the formatted range only — same as VS Code "Format Selection". `--check --range` on a sub-block range of an already-formatted file can therefore report unformatted.
- A range starting on a top-level declaration line whose previous line closes a block may be indented one level (inherited from the shared context algorithm; identical to VS Code behavior). Whole-file `format` restores the file.
- CRLF files are normalized to LF (same as full-file formatting).

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm test` — 1211 passing, 0 failing (matches master baseline)
- [x] CLI tests — 134 passing
- [x] Manual smoke: `--range` on struct fields, block declaration lines, out-of-EOF ranges, `--check`, `--stdin`